### PR TITLE
Changes for DF-beta inclusion

### DIFF
--- a/plugins/modules/df.py
+++ b/plugins/modules/df.py
@@ -251,14 +251,16 @@ class DFService(CdpModule):
 
         # Initialize internal values
         self.target = None
+        self.env_crn = None
 
         # Execute logic process
         self.process()
 
     @CdpModule._Decorators.process_debug
     def process(self):
-        self.name = self.cdpy.environments.resolve_environment_crn(self.name)
-        self.target = self.cdpy.df.describe_environment(env_crn=self.name)
+        self.env_crn = self.cdpy.environments.resolve_environment_crn(self.name)
+        if self.env_crn is not None:
+            self.target = self.cdpy.df.describe_environment(env_crn=self.name)
 
         if self.target is not None:
             # DF Database Entry exists
@@ -266,15 +268,16 @@ class DFService(CdpModule):
                 if self.module.check_mode:
                     self.service = self.target
                 else:
-                    if self.target['status']['state'] != 'NOT_ENABLED':
+                    disable_valid_states = self.cdpy.sdk.TERMINATION_STATES + self.cdpy.sdk.STOPPED_STATES
+                    if self.target['status']['state'] not in disable_valid_states:
                         self.service = self.cdpy.df.disable_environment(
-                            env_crn=self.name,
+                            env_crn=self.env_crn,
                             persist=self.persist
                         )
-                        if self.wait:
-                            self.service = self._wait_for_disabled()
-                        else:
-                            self.service = self.target
+                    if self.wait:
+                        self.service = self._wait_for_disabled()
+                    else:
+                        self.service = self.target
             elif self.state in ['present']:
                 self.module.warn(
                     "Dataflow Service already enabled and configuration validation and reconciliation is not supported;" +
@@ -288,33 +291,36 @@ class DFService(CdpModule):
             # Environment does not have DF database entry, and probably doesn't exist
             if self.state in ['absent']:
                 self.module.log(
-                    "Dataflow Service %s already disabled in CDP Environment" % self.name)
+                    "Dataflow Service %s already disabled in CDP Environment %s" % (self.name, self.env_crn))
             elif self.state in ['present']:
-                # create DF Service
-                if not self.module.check_mode:
-                    self.service = self.cdpy.df.enable_environment(
-                        env_crn=self.name,
-                        authorized_ips=self.ip_ranges,
-                        min_nodes=self.nodes_min,
-                        max_nodes=self.nodes_max,
-                        enable_public_ip=self.public_loadbalancer
-                    )
-                    if self.wait:
-                        self.service = self._wait_for_enabled()
+                if self.env_crn is None:
+                    self.module.fail_json(msg="Could not retrieve CRN for CDP Environment %s" % self.env)
+                else:
+                    # create DF Service
+                    if not self.module.check_mode:
+                        self.service = self.cdpy.df.enable_environment(
+                            env_crn=self.env_crn,
+                            authorized_ips=self.ip_ranges,
+                            min_nodes=self.nodes_min,
+                            max_nodes=self.nodes_max,
+                            enable_public_ip=self.public_loadbalancer
+                        )
+                        if self.wait:
+                            self.service = self._wait_for_enabled()
             else:
                 self.module.fail_json(
                     msg="State %s is not valid for this module" % self.state)
 
     def _wait_for_enabled(self):
         return self.cdpy.sdk.wait_for_state(
-            describe_func=self.cdpy.df.describe_environment, params=dict(env_crn=self.name),
+            describe_func=self.cdpy.df.describe_environment, params=dict(env_crn=self.env_crn),
             field=['status', 'state'], state=self.cdpy.sdk.STARTED_STATES,
             delay=self.delay, timeout=self.timeout
         )
 
     def _wait_for_disabled(self):
         return self.cdpy.sdk.wait_for_state(
-            describe_func=self.cdpy.df.describe_environment, params=dict(env_crn=self.name), state=None,
+            describe_func=self.cdpy.df.describe_environment, params=dict(env_crn=self.env_crn), field=None,
             delay=self.delay, timeout=self.timeout
         )
 

--- a/plugins/modules/env_info.py
+++ b/plugins/modules/env_info.py
@@ -438,7 +438,8 @@ class EnvironmentInfo(CdpModule):
                     'datahub': self.cdpy.datahub.describe_all_clusters(this_env['environmentName']),
                     'dw': self.cdpy.dw.gather_clusters(this_env['crn']),
                     'ml': self.cdpy.ml.describe_all_workspaces(this_env['environmentName']),
-                    'opdb': self.cdpy.opdb.describe_all_databases(this_env['environmentName'])
+                    'opdb': self.cdpy.opdb.describe_all_databases(this_env['environmentName']),
+                    'df': [self.cdpy.df.describe_environment(this_env['crn'])]
                 }
                 updated_envs.append(this_env)
             self.environments = updated_envs


### PR DESCRIPTION
Dependent on https://github.com/cloudera-labs/cdpy/pull/21

Break out usage of environment name from environment crn
Use states from common instead of explicit values for checks
Fix check for wait condition when disabling, should wait if requested regardless of whether disable called or not
Fix attempting to enable when Environment not present
Fix wait for disable incorrectly stipulating that state should be None when it should be checking if field response is None

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>