### PR TITLE
Improve DF Integration

### DIFF
--- a/plugins/modules/df_info.py
+++ b/plugins/modules/df_info.py
@@ -37,6 +37,7 @@ options:
   name:
     description:
       - If a name is provided, that DataFlow Service will be described.
+      - Must be CDP Environment CRN or string name of DataFlow Service
     type: str
     required: False
     aliases:
@@ -168,9 +169,12 @@ class DFInfo(CdpModule):
     @CdpModule._Decorators.process_debug
     def process(self):
         if self.name:  # Note that both None and '' will trigger this
-            service_single = self.cdpy.df.describe_environment(name=self.name)
-            if service_single is not None:
-                self.services.append(service_single)
+            if self.name.startswith('crn:'):
+                service_single = self.cdpy.df.describe_environment(env_crn=self.name)
+                if service_single is not None:
+                    self.services.append(service_single)
+            else:
+                self.services = self.cdpy.df.list_environments(name=self.name)
         else:
             self.services = self.cdpy.df.list_environments()
 

--- a/plugins/modules/env_info.py
+++ b/plugins/modules/env_info.py
@@ -434,12 +434,13 @@ class EnvironmentInfo(CdpModule):
         if self.descendants and self.environments:
             updated_envs = []
             for this_env in self.environments:
+                df = self.cdpy.df.describe_environment(this_env['crn'])
                 this_env['descendants'] = {
                     'datahub': self.cdpy.datahub.describe_all_clusters(this_env['environmentName']),
                     'dw': self.cdpy.dw.gather_clusters(this_env['crn']),
                     'ml': self.cdpy.ml.describe_all_workspaces(this_env['environmentName']),
                     'opdb': self.cdpy.opdb.describe_all_databases(this_env['environmentName']),
-                    'df': [self.cdpy.df.describe_environment(this_env['crn'])]
+                    'df': df if df is not None else []
                 }
                 updated_envs.append(this_env)
             self.environments = updated_envs


### PR DESCRIPTION
Rework DF Disable function and force deletion for better determinism.
Modify df_info to accept either a string name of DF Services, or the CRN of an individual service. This allows for situations where DF Services may be disabled but still listed when needing clean up.
Improve DF listing mechanism in env_info to only retrieve active DF Services which need cleanup before an Environment is removed.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>