### PR TITLE
Add configurable user agent for CDPCLI interface

### DIFF
--- a/plugins/module_utils/cdp_common.py
+++ b/plugins/module_utils/cdp_common.py
@@ -53,6 +53,7 @@ class CdpModule(object):
         self.tls = self._get_param('verify_tls', False)
         self.debug = self._get_param('debug', False)
         self.strict = self._get_param('strict', False)
+        self.agent_header = self._get_param('agent_header', 'ClouderaFoundry')
 
         # Initialize common return values
         self.log_out = None
@@ -66,7 +67,7 @@ class CdpModule(object):
             strict_errors=self.strict,
             error_handler=self._cdp_module_throw_error,
             warning_handler=self._cdp_module_throw_warning,
-            client_name='ClouderaFoundry'
+            client_name=self.agent_header
         )
 
     # Private functions
@@ -94,4 +95,5 @@ class CdpModule(object):
             verify_tls=dict(required=False, type='bool', default=True, aliases=['tls']),
             debug=dict(required=False, type='bool', default=False, aliases=['debug_endpoints']),
             strict=dict(required=False, type='bool', default=False, aliases=['strict_errors']),
+            agent_header=dict(required=False, type='str', default='ClouderaFoundry')
         )


### PR DESCRIPTION
Dependent on:
https://github.com/cloudera-labs/cdpy/pull/34

Add property client_name to cdpy instantiation for configurable user-agent prefix for various downstream clients, with default of CDPY
Add CDPY and version to the user agent for convenient identification
Set cloudera.cloud to client_name of 'ClouderaFoundry'

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>