### PR TITLE
Support for DataFlow Deployments

### DIFF
--- a/plugins/modules/df_customflow_info.py
+++ b/plugins/modules/df_customflow_info.py
@@ -66,7 +66,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 ---
-catalog:
+flows:
   description: The listing of CustomFlow Definitions in the DataFlow Catalog in this CDP Tenant
   type: list
   returned: always

--- a/plugins/modules/df_customflow_info.py
+++ b/plugins/modules/df_customflow_info.py
@@ -46,7 +46,7 @@ options:
     default: True
 
 notes:
-  - This feature this module is for is in Technical Preview
+  - The feature this module is for is in Technical Preview
 extends_documentation_fragment:
   - cloudera.cloud.cdp_sdk_options
   - cloudera.cloud.cdp_auth_options
@@ -81,7 +81,7 @@ flows:
       returned: always
       type: str
     modifiedTimestamp:
-      description: THe timestamp the entry was last modified.
+      description: The timestamp the entry was last modified.
       returned: always
       type: int
     versionCount:

--- a/plugins/modules/df_customflow_info.py
+++ b/plugins/modules/df_customflow_info.py
@@ -88,50 +88,54 @@ flows:
       description: The number of versions uploaded to the catalog.
       returned: always
       type: str
+    artifactType:
+      description: The type of artifact
+      type: str
+      returned: when include_details is False
     createdTimestamp:
       description: The created timestamp.
-      returned: always
+      returned: when include_details is True
       type: int
     author:
       description: Author of the most recent version.
-      returned: always
+      returned: when include_details is True
       type: str
     description:
       description: The artifact description.
-      returned: always
+      returned: when include_details is True
       type: str
     versions:
       description: The list of artifactDetail versions.
-      returned: always
+      returned: when include_details is True
       type: array
       contains:
         crn:
           description: The flow version CRN.
-          returned: always
+          returned: when include_details is True
           type: str
         bucketIdentifier:
           description: The bucketIdentifier of the flow.
-          returned: always
+          returned: when include_details is True
           type: str
         author:
           description: The author of the flow.
-          returned: always
+          returned: when include_details is True
           type: str
         version:
           description: The version of the flow.
-          returned: always
+          returned: when include_details is True
           type: int
         timestamp:
           description: The timestamp of the flow.
-          returned: always
+          returned: when include_details is True
           type: int
         deploymentCount:
           description: The number of deployments of the flow.
-          returned: always
+          returned: when include_details is True
           type: int
         comments:
           description: Comments about the flow.
-          returned: always
+          returned: when include_details is True
           type: str
 sdk_out:
   description: Returns the captured CDP SDK log.

--- a/plugins/modules/df_customflow_info.py
+++ b/plugins/modules/df_customflow_info.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_common import CdpModule
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: df_customflow_info
+short_description: Gather information about CDP DataFlow CustomFlow Definitions
+description:
+    - Gather information about CDP DataFlow CustomFlow Definitions
+author:
+  - "Dan Chaffelson (@chaffelson)"
+requirements:
+  - cdpy
+options:
+  name:
+    description:
+      - If a name is provided, that DataFlow Flow Definition will be described
+    type: str
+    required: False
+  include_details:
+    description:
+      - If set to false, only a summary of each flow is returned
+    type: bool
+    required: False
+    default: True
+
+notes:
+  - This feature this module is for is in Technical Preview
+extends_documentation_fragment:
+  - cloudera.cloud.cdp_sdk_options
+  - cloudera.cloud.cdp_auth_options
+'''
+
+EXAMPLES = r'''
+# Note: These examples do not set authentication details.
+
+# List summary information about all Custom DataFlow Flow Definitions
+- cloudera.cloud.df_customflow_info:
+
+# Gather summary information about a specific DataFlow Flow Definition using a name
+- cloudera.cloud.df_customflow_info:
+    name: my-flow-name
+    include_details: False
+'''
+
+RETURN = r'''
+---
+catalog:
+  description: The listing of CustomFlow Definitions in the DataFlow Catalog in this CDP Tenant
+  type: list
+  returned: always
+  elements: complex
+  contains:
+    crn:
+      description:  The DataFlow Flow Definition's CRN.
+      returned: always
+      type: str
+    name:
+      description: The DataFlow Flow Definition's name.
+      returned: always
+      type: str
+    modifiedTimestamp:
+      description: THe timestamp the entry was last modified.
+      returned: always
+      type: int
+    versionCount:
+      description: The number of versions uploaded to the catalog.
+      returned: always
+      type: str
+    createdTimestamp:
+      description: The created timestamp.
+      returned: always
+      type: int
+    author:
+      description: Author of the most recent version.
+      returned: always
+      type: str
+    description:
+      description: The artifact description.
+      returned: always
+      type: str
+    versions:
+      description: The list of artifactDetail versions.
+      returned: always
+      type: array
+      contains:
+        crn:
+          description: The flow version CRN.
+          returned: always
+          type: str
+        bucketIdentifier:
+          description: The bucketIdentifier of the flow.
+          returned: always
+          type: str
+        author:
+          description: The author of the flow.
+          returned: always
+          type: str
+        version:
+          description: The version of the flow.
+          returned: always
+          type: int
+        timestamp:
+          description: The timestamp of the flow.
+          returned: always
+          type: int
+        deploymentCount:
+          description: The number of deployments of the flow.
+          returned: always
+          type: int
+        comments:
+          description: Comments about the flow.
+          returned: always
+          type: str
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+'''
+
+
+class DFCustomFlowInfo(CdpModule):
+    def __init__(self, module):
+        super(DFCustomFlowInfo, self).__init__(module)
+
+        # Set variables
+        self.name = self._get_param('name')
+        self.include_details = self._get_param('include_details')
+
+        # Initialize internal values
+        self.listing = []
+
+        # Initialize return values
+        self.flows = []
+
+        # Execute logic process
+        self.process()
+
+    @CdpModule._Decorators.process_debug
+    def process(self):
+        self.listing = self.cdpy.df.list_flow_definitions(name=self.name)
+        if self.include_details:
+            self.flows = [
+                self.cdpy.df.describe_customflow(x['crn'])
+                for x in self.listing
+                if x['artifactType'] == 'flow'  # ReadyFlow have different fields
+            ]
+        else:
+            self.flows = self.listing
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=CdpModule.argument_spec(
+            name=dict(required=False, type='str'),
+            include_details=dict(required=False, type='bool', default=True)
+        ),
+        supports_check_mode=True
+    )
+
+    result = DFCustomFlowInfo(module)
+    output = dict(changed=False, flows=result.flows)
+
+    if result.debug:
+        output.update(sdk_out=result.log_out, sdk_out_lines=result.log_lines)
+
+    module.exit_json(**output)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/df_deployment.py
+++ b/plugins/modules/df_deployment.py
@@ -306,7 +306,7 @@ class DFDeployment(CdpModule):
         self.timeout = self._get_param('timeout')
 
         # Initialize return values
-        self.deployment = {}
+        self.deployment = None
         self.changed = False
 
         # Initialize internal values
@@ -335,6 +335,8 @@ class DFDeployment(CdpModule):
             if self.state in ['absent']:
                 # Existing Deployment to be removed
                 if self.module.check_mode:
+                    self.module.log(
+                        "Check mode enabled, skipping termination of Deployment %s" % self.dep_crn)
                     self.deployment = self.target
                 else:
                     self._terminate_deployment()

--- a/plugins/modules/df_deployment.py
+++ b/plugins/modules/df_deployment.py
@@ -138,7 +138,7 @@ options:
   parameter_groups:
     description:
       - Definitions of Parameters to apply to the Deployed Flow
-    type: dict
+    type: array
     required: False
   kpis:
     description:
@@ -435,7 +435,7 @@ def main():
             autoscale_nodes_max=dict(type='int', default=3),
             nifi_ver=dict(type='str', default=None),
             autostart_flow=dict(type='bool', default=True),
-            parameter_groups=dict(type='dict', default=None),
+            parameter_groups=dict(type='list', default=None),
             kpis=dict(type='list', default=None),
             state=dict(type='str', choices=['present', 'absent'],
                        default='present'),

--- a/plugins/modules/df_deployment_info.py
+++ b/plugins/modules/df_deployment_info.py
@@ -33,17 +33,18 @@ author:
 requirements:
   - cdpy
 options:
-  name:
+  crn:
     description:
-      - If a name is provided, that DataFlow Deployment will be described
-      - Must be the string CRN of the deployment
+      - If a crn is provided, that DataFlow Deployment will be described
+      - Must be the string CRN of the deployment object
     type: str
     aliases:
       - dep_crn
+      - name
     required: False
 
 notes:
-  - This feature this module is for is in Technical Preview
+  - The feature this module is for is in Technical Preview
 extends_documentation_fragment:
   - cloudera.cloud.cdp_sdk_options
   - cloudera.cloud.cdp_auth_options
@@ -77,7 +78,7 @@ deployments:
       returned: always
       type: str
     status:
-      description: The status of a DataFlow enabled environment.
+      description: The status of a DataFlow deployment.
       returned: always
       type: dict
       contains:
@@ -107,11 +108,11 @@ deployments:
           returned: always
           type: str
         cloudProvider:
-          description: the cloud provider for the parent environment.
+          description: The cloud provider for the parent environment.
           returned: always
           type: str
         region:
-          description:  the region within the parent environment cloud provider.
+          description: The region within the parent environment cloud provider.
           returned: always
           type: str
         environmentCrn:
@@ -167,7 +168,7 @@ deployments:
       returned: always
       type: bool
     autoscaleMinNodes:
-      description: The  minimum  number of nodes that the deployment will allocate. May only be specified when autoscalingEnabled is true.
+      description: The minimum number of nodes that the deployment will allocate. May only be specified when autoscalingEnabled is true.
       returned: always
       type: int
     activeWarningAlertCount:
@@ -179,7 +180,7 @@ deployments:
       returned: always
       type: int
     staticNodeCount:
-      description: The static number of nodes that the  deployment  will  allocate. May only be specified when autoscalingEnabled is false.
+      description: The static number of nodes that the deployment will allocate. May only be specified when autoscalingEnabled is false.
       returned: always
       type: int
     dfxLocalUrl:

--- a/plugins/modules/df_deployment_info.py
+++ b/plugins/modules/df_deployment_info.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module:f_deployment_info
+module: df_deployment_info
 short_description: Gather information about CDP DataFlow Deployments
 description:
     - Gather information about CDP DataFlow Deployments

--- a/plugins/modules/df_deployment_info.py
+++ b/plugins/modules/df_deployment_info.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: df_deployment_info
+module:f_deployment_info
 short_description: Gather information about CDP DataFlow Deployments
 description:
     - Gather information about CDP DataFlow Deployments
@@ -80,7 +80,7 @@ deployments:
     status:
       description: The status of a DataFlow deployment.
       returned: always
-      type: dict
+      type:ict
       contains:
         state:
           description: The state of the Deployment.
@@ -97,7 +97,7 @@ deployments:
     service:
       description: Metadata about the parent DataFlow service.
       returned: always
-      type: dict
+      type:ict
       contains:
         crn:
           description: The crn of the parent service.
@@ -122,7 +122,7 @@ deployments:
     updated:
       description: Timestamp of the last time the deployment was modified.
       returned: always
-      type: str
+      type: int
     clusterSize:
       description: The initial size of the deployment.
       returned: always
@@ -222,10 +222,7 @@ class DFDeploymentInfo(CdpModule):
 
     @CdpModule._Decorators.process_debug
     def process(self):
-        if self.name is not None:
-            self.deployments = [self.cdpy.df.describe_deployment(dep_crn=self.name)]
-        else:
-            self.deployments = self.cdpy.df.list_deployments()
+        self.deployments = self.cdpy.df.list_deployments(dep_crn=self.name, described=True)
 
 
 def main():

--- a/plugins/modules/df_deployment_info.py
+++ b/plugins/modules/df_deployment_info.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_common import CdpModule
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: df_deployment_info
+short_description: Gather information about CDP DataFlow Deployments
+description:
+    - Gather information about CDP DataFlow Deployments
+author:
+  - "Dan Chaffelson (@chaffelson)"
+requirements:
+  - cdpy
+options:
+  name:
+    description:
+      - If a name is provided, that DataFlow Deployment will be described
+      - Must be the string CRN of the deployment
+    type: str
+    aliases:
+      - dep_crn
+    required: False
+
+notes:
+  - This feature this module is for is in Technical Preview
+extends_documentation_fragment:
+  - cloudera.cloud.cdp_sdk_options
+  - cloudera.cloud.cdp_auth_options
+'''
+
+EXAMPLES = r'''
+# Note: These examples do not set authentication details.
+
+# List basic information about all DataFlow Deployments
+- cloudera.cloud.df_deployment_info:
+
+# Gather detailed information about a named DataFlow Deployment using a name
+- cloudera.cloud.df_deployment_info:
+    name: crn:cdp:df:region:tenant-uuid4:deployment:deployment-uuid4/deployment-uuid4
+'''
+
+RETURN = r'''
+---
+deployments:
+  description: The information about the named DataFlow Deployment or DataFlow Deployments
+  type: list
+  returned: always
+  elements: complex
+  contains:
+    crn:
+      description:  The DataFlow Deployment's CRN.
+      returned: always
+      type: str
+    name:
+      description: The DataFlow Deployment's name.
+      returned: always
+      type: str
+    status:
+      description: The status of a DataFlow enabled environment.
+      returned: always
+      type: dict
+      contains:
+        state:
+          description: The state of the Deployment.
+          returned: always
+          type: str
+        detailedState:
+          description: The state of the Deployment.
+          returned: always
+          type: str
+        message:
+          description: A status message for the Deployment.
+          returned: always
+          type: str
+    service:
+      description: Metadata about the parent DataFlow service.
+      returned: always
+      type: dict
+      contains:
+        crn:
+          description: The crn of the parent service.
+          returned: always
+          type: str
+        name:
+          description: The name of the parent environment.
+          returned: always
+          type: str
+        cloudProvider:
+          description: the cloud provider for the parent environment.
+          returned: always
+          type: str
+        region:
+          description:  the region within the parent environment cloud provider.
+          returned: always
+          type: str
+        environmentCrn:
+          description: The CDP parent Environment CRN.
+          returned: always
+          type: str
+    updated:
+      description: Timestamp of the last time the deployment was modified.
+      returned: always
+      type: str
+    clusterSize:
+      description: The initial size of the deployment.
+      returned: always
+      type: str
+    flowVersionCrn:
+      description: The deployment's current flow version CRN.
+      returned: always
+      type: str
+    flowCrn:
+      description:  The deployment's current flow CRN.
+      returned: always
+      type: str
+    nifiUrl:
+      description: The url to open the deployed flow in NiFi.
+      returned: always
+      type: str
+    autoscaleMaxNodes:
+      description: The maximum number of nodes that the deployment can scale up to, or null if autoscaling is not enabled for this deployment.
+      returned: always
+      type: complex
+    flowName:
+      description: The name of the flow.
+      returned: always
+      type: str
+    flowVersion:
+      description: The version of the flow.
+      returned: always
+      type: int
+    currentNodeCount:
+      description:  The current node count.
+      returned: always
+      type: int
+    deployedByCrn:
+      description: The actor CRN of the person who deployed the flow.
+      returned: always
+      type: str
+    deployedByName:
+      description: The name of the person who deployed the flow.
+      returned: always
+      type: complex
+    autoscalingEnabled:
+      description: Whether or not to autoscale the deployment.
+      returned: always
+      type: bool
+    autoscaleMinNodes:
+      description: The  minimum  number of nodes that the deployment will allocate. May only be specified when autoscalingEnabled is true.
+      returned: always
+      type: int
+    activeWarningAlertCount:
+      description:  Current count of active alerts classified as a warning.
+      returned: always
+      type: int
+    activeErrorAlertCount:
+      description: Current count of active alerts classified as an error.
+      returned: always
+      type: int
+    staticNodeCount:
+      description: The static number of nodes that the  deployment  will  allocate. May only be specified when autoscalingEnabled is false.
+      returned: always
+      type: int
+    dfxLocalUrl:
+      description: Base URL to the DFX Local instance running this deployment.
+      returned: always
+      type: string
+    lastUpdatedByName:
+      description:  The name of the person who last updated the deployment.
+      returned: always
+      type: string
+    configurationVersion:
+      description: The version of the configuration for this deployment.
+      returned: always
+      type: int
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+'''
+
+
+class DFDeploymentInfo(CdpModule):
+    def __init__(self, module):
+        super(DFDeploymentInfo, self).__init__(module)
+
+        # Set variables
+        self.name = self._get_param('name')
+
+        # Initialize return values
+        self.deployments = []
+
+        # Execute logic process
+        self.process()
+
+    @CdpModule._Decorators.process_debug
+    def process(self):
+        if self.name is not None:
+            self.deployments = [self.cdpy.df.describe_deployment(dep_crn=self.name)]
+        else:
+            self.deployments = self.cdpy.df.list_deployments()
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=CdpModule.argument_spec(
+            name=dict(required=False, type='str', aliases=['crn', 'dep_crn'])
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=['name', 'df_crn', 'env_crn']
+    )
+
+    result = DFDeploymentInfo(module)
+    output = dict(changed=False, deployments=result.deployments)
+
+    if result.debug:
+        output.update(sdk_out=result.log_out, sdk_out_lines=result.log_lines)
+
+    module.exit_json(**output)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/df_readyflow.py
+++ b/plugins/modules/df_readyflow.py
@@ -192,7 +192,6 @@ class DFReadyFlow(CdpModule):
 
         # Set variables
         self.name = self._get_param('name')
-        self.include_details = self._get_param('include_details')
         self.state = self._get_param('state')
 
         # Initialize internal values

--- a/plugins/modules/df_readyflow.py
+++ b/plugins/modules/df_readyflow.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_common import CdpModule
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: df_readyflow
+short_description: Import or Delete ReadyFlows from your CDP Tenant
+description:
+    - Import or Delete ReadyFlows from your CDP Tenant
+author:
+  - "Dan Chaffelson (@chaffelson)"
+requirements:
+  - cdpy
+options:
+  name:
+    description:
+      - If a name is provided, that DataFlow ReadyFlow Definition will be described
+    type: str
+    required: False
+  state:
+    description:
+      - The declarative state of the ReadyFlow
+    type: str
+    required: False
+    default: present
+    choices:
+      - present
+      - absent
+
+notes:
+  - This feature this module is for is in Technical Preview
+extends_documentation_fragment:
+  - cloudera.cloud.cdp_sdk_options
+  - cloudera.cloud.cdp_auth_options
+'''
+
+EXAMPLES = r'''
+# Note: These examples do not set authentication details.
+
+# Import a ReadyFlow into your CDP Tenant
+- cloudera.cloud.df_readyflow:
+    name: my-readyflow-name
+
+# Delete an added ReadyFlow from your CDP Tenant
+- cloudera.cloud.df_readyflow:
+    name: my-readyflow-name
+    state: absent
+'''
+
+RETURN = r'''
+---
+readyflow:
+  description: The listing of ReadyFlow Definitions in the DataFlow Catalog in this CDP Tenant
+  type: list
+  returned: always
+  elements: complex
+  contains:
+    readyflowCrn:
+      description:  
+        - The DataFlow readyflow Definition's CRN.
+        - Use this readyflowCrn to address this object
+      returned: always
+      type: str
+    readyflow:
+      description: The details of the ReadyFlow object
+      type: dict
+      returned: always
+      elements: complex
+      contains:
+        readyflowCrn:
+          description:
+            - The general base crn of this ReadyFlow
+            - Different to the unique readyflowCrn containing a UUID4
+          returned: always
+          type: str
+        name:
+          description: The DataFlow Flow Definition's name.
+          returned: always
+          type: str
+        author:
+          description: Author of the most recent version.
+          returned: always
+          type: str
+        summary:
+          description: The ready flow summary (short).
+          returned: always
+          type: str
+        description:
+          description: The ready flow description (long).
+          returned: always
+          type: str
+        documentationLink:
+          description: A link to the ready flow documentation.
+          returned: always
+          type: str
+        notes:
+          description: Optional notes about the ready flow.
+          returned: always
+          type: str
+        source:
+          description: The ready flow data source.
+          returned: always
+          type: str
+        sourceDataFormat:
+          description: The ready flow data source format.
+          returned: always
+          type: str
+        destination:
+          description: The ready flow data destination.
+          returned: always
+          type: str
+        destinationDataFormat:
+          description: The ready flow data destination format.
+          returned: always
+          type: str
+        imported:
+          description: Whether  the  ready  flow  has been imported into the current account.
+          returned: always
+          type: bool         
+        modifiedTimestamp:
+          description: THe timestamp the entry was last modified.
+          returned: always
+          type: int
+    versions:
+      description: The list of artifactDetail versions.
+      returned: When imported is True
+      type: array
+      contains:
+        crn:
+          description: The artifact version CRN.
+          returned: always
+          type: str
+        bucketIdentifier:
+          description: The bucketIdentifier of the flow.
+          returned: always
+          type: str
+        author:
+          description: The author of the artifact.
+          returned: always
+          type: str
+        version:
+          description: The version of the artifact.
+          returned: always
+          type: int
+        timestamp:
+          description: The timestamp of the artifact.
+          returned: always
+          type: int
+        deploymentCount:
+          description: The number of deployments of the artifact.
+          returned: always
+          type: int
+        comments:
+          description: Comments about the version.
+          returned: always
+          type: str
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+'''
+
+
+class DFReadyFlow(CdpModule):
+    def __init__(self, module):
+        super(DFReadyFlow, self).__init__(module)
+
+        # Set variables
+        self.name = self._get_param('name')
+        self.include_details = self._get_param('include_details')
+        self.state = self._get_param('state')
+
+        # Initialize internal values
+        self.target = None
+        self.listing = None
+
+        # Initialize return values
+        self.readyflow = None
+        self.changed = False
+
+        # Execute logic process
+        self.process()
+
+    @CdpModule._Decorators.process_debug
+    def process(self):
+        self.listing = self.cdpy.df.list_readyflows(name=self.name)
+        if not self.listing:  # return is list with one item if name exists, as name is unique
+            self.module.fail_json(
+                msg="ReadyFlow with Name %s is not found" % self.name)
+        else:
+            self.target = self.listing[0]
+            if self.target['imported']:  # field is bool
+                if self.state == 'present':
+                    # ReadyFlow is imported and should be left alone
+                    # helpfully return the detailed description
+                    self.readyflow = self.cdpy.df.describe_added_readyflow(
+                        def_crn=self.target['importedArtifactCrn']
+                    )
+                if self.state == 'absent':
+                    if not self.module.check_mode:
+                        # ReadyFlow is imported and should be deleted
+                        self.readyflow = self.cdpy.df.delete_added_readyflow(
+                            def_crn=self.target['importedArtifactCrn']
+                        )
+                        self.changed = True
+                    else:
+                        self.module.log(
+                            "Check mode enabled, skipping deletion of %s" % self.name)
+            else:
+                if self.state == 'present':
+                    # ReadyFlow should be imported
+                    if not self.module.check_mode:
+                        self.readyflow = self.cdpy.df.import_readyflow(
+                            def_crn=self.target['readyflowCrn']
+                        )
+                        self.changed = True
+                    else:
+                        self.module.log(
+                            "Check mode enabled, skipping import of %s" % self.name)
+                if self.state == 'absent':
+                    # ReadyFlow is not imported and should stay that way
+                    self.module.log(
+                        "ReadyFlow already not imported to CDP Tenant %s" % self.name)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=CdpModule.argument_spec(
+            name=dict(required=True, type='str'),
+            state=dict(type='str', choices=['present', 'absent'],
+                       default='present'),
+        ),
+        supports_check_mode=True
+    )
+
+    result = DFReadyFlow(module)
+    output = dict(changed=result.changed, readyflow=result.readyflow)
+
+    if result.debug:
+        output.update(sdk_out=result.log_out, sdk_out_lines=result.log_lines)
+
+    module.exit_json(**output)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/df_readyflow.py
+++ b/plugins/modules/df_readyflow.py
@@ -35,9 +35,9 @@ requirements:
 options:
   name:
     description:
-      - If a name is provided, that DataFlow ReadyFlow Definition will be described
+      - The name of the ReadyFlow to be acted upon.
     type: str
-    required: False
+    required: True
   state:
     description:
       - The declarative state of the ReadyFlow
@@ -71,11 +71,10 @@ EXAMPLES = r'''
 RETURN = r'''
 ---
 readyflow:
-  description: The listing of ReadyFlow Definitions in the DataFlow Catalog in this CDP Tenant
-  type: list
-  returned: always
+  description: The ReadyFlow Definition
+  type: dict
   elements: complex
-  contains:
+  returned: always
     readyflowCrn:
       description:  
         - The DataFlow readyflow Definition's CRN.
@@ -85,7 +84,7 @@ readyflow:
     readyflow:
       description: The details of the ReadyFlow object
       type: dict
-      returned: always
+      returned: varies
       elements: complex
       contains:
         readyflowCrn:
@@ -135,11 +134,11 @@ readyflow:
           returned: always
           type: str
         imported:
-          description: Whether  the  ready  flow  has been imported into the current account.
+          description: Whether the ready flow has been imported into the current account.
           returned: always
           type: bool         
         modifiedTimestamp:
-          description: THe timestamp the entry was last modified.
+          description: The timestamp the entry was last modified.
           returned: always
           type: int
     versions:

--- a/plugins/modules/df_readyflow_info.py
+++ b/plugins/modules/df_readyflow_info.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_common import CdpModule
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: df_readyflow_info
+short_description: Gather information about CDP DataFlow CustomFlow Definitions
+description:
+    - Gather information about CDP DataFlow ReadyFlow Definitions
+author:
+  - "Dan Chaffelson (@chaffelson)"
+requirements:
+  - cdpy
+options:
+  name:
+    description:
+      - If a name is provided, that DataFlow ReadyFlow Definition will be described
+    type: str
+    required: False
+  include_details:
+    description:
+      - If set to false, only a summary of each ReadyFlow Definition is returned
+    type: bool
+    required: False
+    default: True
+
+notes:
+  - This feature this module is for is in Technical Preview
+extends_documentation_fragment:
+  - cloudera.cloud.cdp_sdk_options
+  - cloudera.cloud.cdp_auth_options
+'''
+
+EXAMPLES = r'''
+# Note: These examples do not set authentication details.
+
+# List summary information about all Custom DataFlow ReadyFlow Definitions
+- cloudera.cloud.df_readyflow_info:
+
+# Gather summary information about a specific DataFlow Flow Definition using a name
+- cloudera.cloud.df_readyflow_info:
+    name: my-flow-name
+    include_details: False
+'''
+
+RETURN = r'''
+---
+flows:
+  description: The listing of ReadyFlow Definitions in the DataFlow Catalog in this CDP Tenant
+  type: list
+  returned: always
+  elements: complex
+  contains:
+    readyflowCrn:
+      description:  
+        - The DataFlow readyflow Definition's CRN.
+        - Use this readyflowCrn to address this object
+      returned: always
+      type: str
+    readyflow:
+      description: The details of the ReadyFlow object
+      type: dict
+      returned: always
+      elements: complex
+      contains:
+        readyflowCrn:
+          description:
+            - The general base crn of this ReadyFlow
+            - Different to the unique readyflowCrn containing a UUID4
+          returned: always
+          type: str
+        name:
+          description: The DataFlow Flow Definition's name.
+          returned: always
+          type: str
+        author:
+          description: Author of the most recent version.
+          returned: always
+          type: str
+        summary:
+          description: The ready flow summary (short).
+          returned: always
+          type: str
+        description:
+          description: The ready flow description (long).
+          returned: always
+          type: str
+        documentationLink:
+          description: A link to the ready flow documentation.
+          returned: always
+          type: str
+        notes:
+          description: Optional notes about the ready flow.
+          returned: always
+          type: str
+        source:
+          description: The ready flow data source.
+          returned: always
+          type: str
+        sourceDataFormat:
+          description: The ready flow data source format.
+          returned: always
+          type: str
+        destination:
+          description: The ready flow data destination.
+          returned: always
+          type: str
+        destinationDataFormat:
+          description: The ready flow data destination format.
+          returned: always
+          type: str
+        imported:
+          description: Whether  the  ready  flow  has been imported into the current account.
+          returned: always
+          type: bool         
+        modifiedTimestamp:
+          description: THe timestamp the entry was last modified.
+          returned: always
+          type: int
+    versions:
+      description: The list of artifactDetail versions.
+      returned: When imported is True
+      type: array
+      contains:
+        crn:
+          description: The artifact version CRN.
+          returned: always
+          type: str
+        bucketIdentifier:
+          description: The bucketIdentifier of the flow.
+          returned: always
+          type: str
+        author:
+          description: The author of the artifact.
+          returned: always
+          type: str
+        version:
+          description: The version of the artifact.
+          returned: always
+          type: int
+        timestamp:
+          description: The timestamp of the artifact.
+          returned: always
+          type: int
+        deploymentCount:
+          description: The number of deployments of the artifact.
+          returned: always
+          type: int
+        comments:
+          description: Comments about the version.
+          returned: always
+          type: str
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+'''
+
+
+class DFReadyFlowInfo(CdpModule):
+    def __init__(self, module):
+        super(DFReadyFlowInfo, self).__init__(module)
+
+        # Set variables
+        self.name = self._get_param('name')
+        self.include_details = self._get_param('include_details')
+
+        # Initialize internal values
+        self.listing = []
+
+        # Initialize return values
+        self.flows = []
+
+        # Execute logic process
+        self.process()
+
+    @CdpModule._Decorators.process_debug
+    def process(self):
+        self.listing = self.cdpy.df.list_readyflows(name=self.name)
+        if self.include_details and self.listing:
+            self.flows = []
+            for this_readyflow in self.listing:
+                if this_readyflow['imported']:
+                    self.flows.append(
+                        self.cdpy.df.describe_added_readyflow(
+                            def_crn=this_readyflow['importedArtifactCrn']
+                        )
+                    )
+                else:
+                    self.flows.append(
+                        self.cdpy.df.describe_readyflow(
+                            def_crn=this_readyflow['readyflowCrn']
+                        )
+                    )
+        else:
+            self.flows = self.listing
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=CdpModule.argument_spec(
+            name=dict(required=False, type='str'),
+            include_details=dict(required=False, type='bool', default=True)
+        ),
+        supports_check_mode=True
+    )
+
+    result = DFReadyFlowInfo(module)
+    output = dict(changed=False, flows=result.flows)
+
+    if result.debug:
+        output.update(sdk_out=result.log_out, sdk_out_lines=result.log_lines)
+
+    module.exit_json(**output)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/df_readyflow_info.py
+++ b/plugins/modules/df_readyflow_info.py
@@ -61,7 +61,6 @@ EXAMPLES = r'''
 # Gather summary information about a specific DataFlow Flow Definition using a name
 - cloudera.cloud.df_readyflow_info:
     name: my-flow-name
-    include_details: False
 '''
 
 RETURN = r'''
@@ -72,11 +71,11 @@ flows:
   returned: always
   elements: complex
   contains:
-    readyflowCrn:
+    addedReadyflowCrn:
       description:
-        - The DataFlow readyflow Definition's CRN.
-        - Use this readyflowCrn to address this object
-      returned: always
+        - The CRN of this readyflow when it is imported to the CDP Tenant
+        - Use this readyflowCrn to address this object when doing deployments
+      returned: when readyflow imported is True
       type: str
     readyflow:
       description: The details of the ReadyFlow object
@@ -86,8 +85,9 @@ flows:
       contains:
         readyflowCrn:
           description:
-            - The general base crn of this ReadyFlow
-            - Different to the unique readyflowCrn containing a UUID4
+            - The CRN of this readyflow in the Control Plane
+            - Different to the addedReadyflowCrn of the imported readyflow within the CDP Tenant
+            - Use this readyflowCrn when importing the object to your CDP Tenant
           returned: always
           type: str
         name:
@@ -189,7 +189,6 @@ class DFReadyFlowInfo(CdpModule):
 
         # Set variables
         self.name = self._get_param('name')
-        self.include_details = self._get_param('include_details')
 
         # Initialize internal values
         self.listing = []
@@ -203,7 +202,7 @@ class DFReadyFlowInfo(CdpModule):
     @CdpModule._Decorators.process_debug
     def process(self):
         self.listing = self.cdpy.df.list_readyflows(name=self.name)
-        if self.include_details and self.listing:
+        if self.listing:
             self.flows = []
             for this_readyflow in self.listing:
                 if this_readyflow['imported']:
@@ -226,7 +225,6 @@ def main():
     module = AnsibleModule(
         argument_spec=CdpModule.argument_spec(
             name=dict(required=False, type='str'),
-            include_details=dict(required=False, type='bool', default=True)
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/df_readyflow_info.py
+++ b/plugins/modules/df_readyflow_info.py
@@ -73,7 +73,7 @@ flows:
   elements: complex
   contains:
     readyflowCrn:
-      description:  
+      description:
         - The DataFlow readyflow Definition's CRN.
         - Use this readyflowCrn to address this object
       returned: always
@@ -131,11 +131,11 @@ flows:
           returned: always
           type: str
         imported:
-          description: Whether  the  ready  flow  has been imported into the current account.
+          description: Whether the ready flow has been imported into the current account.
           returned: always
-          type: bool         
+          type: bool
         modifiedTimestamp:
-          description: THe timestamp the entry was last modified.
+          description: The timestamp the entry was last modified.
           returned: always
           type: int
     versions:

--- a/plugins/modules/df_service.py
+++ b/plugins/modules/df_service.py
@@ -38,7 +38,7 @@ options:
         - The CRN of the CDP Environment to host the Dataflow Service
         - Required when state is present
     type: str
-    required: Conditional
+    required: False
     aliases:
       - name
       - crn

--- a/plugins/modules/df_service.py
+++ b/plugins/modules/df_service.py
@@ -304,7 +304,6 @@ class DFService(CdpModule):
                 if self.env_crn is None:
                     self.module.fail_json(msg="Could not retrieve CRN for CDP Environment %s" % self.env)
                 else:
-                    df_tags = [{'key': x, 'value': self.tags[x]} for x in self.tags] if self.tags is not None else None
                     # create DF Service
                     if not self.module.check_mode:
                         self.service = self.cdpy.df.enable_service(
@@ -314,7 +313,7 @@ class DFService(CdpModule):
                             enable_public_ip=self.public_loadbalancer,
                             lb_ips=self.lb_ip_ranges,
                             kube_ips=self.kube_ip_ranges,
-                            tags=df_tags,
+                            # tags=self.tags,  # Currently overstrict blocking of values
                             cluster_subnets=self.cluster_subnets,
                             lb_subnets=self.lb_subnets
                         )

--- a/plugins/modules/df_service.py
+++ b/plugins/modules/df_service.py
@@ -33,13 +33,21 @@ author:
 requirements:
   - cdpy
 options:
-  crn:
-    description: The name or crn of the CDP Environment to host the Dataflow Service
+  env_crn:
+    description: 
+        - The CRN of the CDP Environment to host the Dataflow Service
+        - Required when state is present
     type: str
-    required: True
+    required: Conditional
     aliases:
       - name
-      - env_crn
+      - crn
+  df_crn:
+    description: 
+        - The CRN of the DataFlow Service, if available
+        - Required when state is absent
+    type: str
+    required: Conditional
   state:
     description:
       - The declarative state of the Dataflow Service
@@ -48,9 +56,7 @@ options:
     default: present
     choices:
       - present
-      - enabled
       - absent
-      - disabled
   nodes_min:
     description: The minimum number of kubernetes nodes needed for the environment.
       Note that the lowest minimum is 3 nodes.

--- a/plugins/modules/df_service_info.py
+++ b/plugins/modules/df_service_info.py
@@ -82,14 +82,18 @@ EXAMPLES = r'''
 
 RETURN = r'''
 ---
-environments:
+services:
   description: The information about the named DataFlow Service or DataFlow Services
   type: list
   returned: always
   elements: complex
   contains:
     crn:
-      description:  The DataFlow Service's parent environment CRN.
+      description:  The DataFlow Service's CRN.
+      returned: always
+      type: str
+    environmentCrn:
+      description:  The DataFlow Service's Parent Environment CRN.
       returned: always
       type: str
     name:
@@ -209,7 +213,7 @@ def main():
         mutually_exclusive=['name', 'df_crn', 'env_crn']
     )
 
-    result = DFInfo(module)
+    result = DFServiceInfo(module)
     output = dict(changed=False, services=result.services)
 
     if result.debug:

--- a/plugins/modules/df_service_info.py
+++ b/plugins/modules/df_service_info.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: df_info
+module: df_service_info
 short_description: Gather information about CDP DataFlow Services
 description:
     - Gather information about CDP DataFlow Services
@@ -169,9 +169,9 @@ sdk_out_lines:
 '''
 
 
-class DFInfo(CdpModule):
+class DFServiceInfo(CdpModule):
     def __init__(self, module):
-        super(DFInfo, self).__init__(module)
+        super(DFServiceInfo, self).__init__(module)
 
         # Set variables
         self.name = self._get_param('name')


### PR DESCRIPTION
Requires:
https://github.com/cloudera-labs/cdpy/pull/40

Add df_customflow_info module, a custom flow is a user supplied flow definition and behaves differently from a readyflow
Add df_deployment module, for actually deploying or removing any kind of flow
Add df_deployment_info module, info on deployments
Add df_readyflow module, for adding or removing ReadyFlows from a given Tenant
Add df_readyflow_info module
Update df_service to support Tags for the DFX Service
Correct check_mode behavior for df_service, and fix idempotent termination issue
Fix docs and classnames in df_service_info

Note that significant logic is pushed down into cdpy to handle resolution of various CRNs and Names, and the extensive deployment logic for DF Deployments is lifted from CDPCLI.