### PR TITLE
Add parameter for control plane region

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@
 
 namespace: cloudera
 name: cloud
-version: 1.7.0
+version: 1.7.1
 readme: README.md
 authors:
 - Webster Mudge <wmudge@cloudera.com>


### PR DESCRIPTION
With this patch we managed to successfully create an environment in the EU control plane. 

- used the same name (cp_region) as in cdpy
- set the default cp_region to "default" which seemed to be the default in cdpy
- made no changes to documentation