### PR TITLE
Fix documentation on datahub name length

### DIFF
--- a/docs/_sources/datahub_cluster.rst.txt
+++ b/docs/_sources/datahub_cluster.rst.txt
@@ -44,7 +44,7 @@ Parameters
    | **Parameter**   | **Choices/Defaults**  | **Comments**                                                                                                                     |
    +-----------------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------+
    | **name**        |                       | The name of the datahub.                                                                                                         |
-   |                 |                       | This name must be unique, must have between 5 and 100 characters, and must contain only lowercase letters, numbers, and hyphens. |
+   |                 |                       | This name must be unique, must have between 5 and 20 characters, and must contain only lowercase letters, numbers, and hyphens. |
    | |br|            |                       | Names are case-sensitive.                                                                                                        |
    |                 |                       |                                                                                                                                  |
    | ``str``         |                       |                                                                                                                                  |

--- a/docs/datahub_cluster.html
+++ b/docs/datahub_cluster.html
@@ -255,7 +255,7 @@
 </td>
 <td></td>
 <td><p>The name of the datahub.
-This name must be unique, must have between 5 and 100 characters, and must contain only lowercase letters, numbers, and hyphens.
+This name must be unique, must have between 5 and 20 characters, and must contain only lowercase letters, numbers, and hyphens.
 Names are case-sensitive.</p>
 <p><br /></p>
 <p><em>Aliases: datahub</em></p>

--- a/docsrc/datahub_cluster.rst
+++ b/docsrc/datahub_cluster.rst
@@ -44,7 +44,7 @@ Parameters
    | **Parameter**   | **Choices/Defaults**  | **Comments**                                                                                                                     |
    +-----------------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------+
    | **name**        |                       | The name of the datahub.                                                                                                         |
-   |                 |                       | This name must be unique, must have between 5 and 100 characters, and must contain only lowercase letters, numbers, and hyphens. |
+   |                 |                       | This name must be unique, must have between 5 and 20 characters, and must contain only lowercase letters, numbers, and hyphens. |
    | |br|            |                       | Names are case-sensitive.                                                                                                        |
    |                 |                       |                                                                                                                                  |
    | ``str``         |                       |                                                                                                                                  |

--- a/plugins/modules/datahub_cluster.py
+++ b/plugins/modules/datahub_cluster.py
@@ -38,7 +38,7 @@ options:
   name:
     description:
       - The name of the datahub.
-      - This name must be unique, must have between 5 and 100 characters, and must contain only lowercase letters,
+      - This name must be unique, must have between 5 and 20 characters, and must contain only lowercase letters,
         numbers, and hyphens.
       - Names are case-sensitive.
     type: str


### PR DESCRIPTION
To match [what will be enforced by cloudera.exe](https://github.com/cloudera-labs/cloudera.exe/blob/76952bd741767c6a432ef31ee41ae27f20b41d07/roles/runtime/tasks/validate_base.yml#L39) and [OPSAPS-58753](https://jira.cloudera.com/browse/OPSAPS-58753).

It's just a change in the documentation and no code changes, so I think there is nothing to test.