### PR TITLE
Add integration targets for CDP Environment and general teardown

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,65 @@
+# Testing
+
+The [ansible-test](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html#testing-collections) tool can run a number of testing strategies, notably `sanity`, `units`, and `integration` tests. 
+
+## Set up ansible-test
+
+To prepare `ansible-test`, you will need to tackle the following steps:
+
+- Install the collection (and its dependencies) and set the `ANSIBLE_COLLECTIONS_PATHS` accordingly.
+- Create a virtual environment
+
+  `ansible-test` currently requires Python<=3.10.
+
+  You can "go basic":
+  ```bash
+  python3.10 -m venv ~/.venv/cloud-test
+  ```
+
+  Or use your favorite wrapper
+  ```bash
+  mkvirtualenv -p py310 cloud-test
+  ```
+- Install Ansible and testing requirements.
+  
+  Typically, this should be the latest stable Ansible.
+  ```bash
+  pip install 'ansible-core>=2.14,<2.15' mock pytest pytest-xdist pytest-mock pytest-forked
+  ```
+  If you need to test with <2.14, you will need to adjust the `pip` libraries accordingly.
+  ```bash
+  pip install 'ansible-core>=2.12,<2.13' mock pytest 'pytest-xdist==2.5.0' pytest-mock pytest-forked
+  ```
+- Install the collection's Python requirements.
+  ```bash
+  pip install -r requirements.txt
+  ```
+  NOTE: if you are also testing changes with `cdpy`, you will want to install that package locally, i.e. `pip install -e <directory to cdpy>`.
+
+## Run the unit tests
+
+Unit tests are implemented in `pytest`.
+
+```bash
+ansible-test units --python 3.10
+```
+
+## Run the integration tests
+
+The collection integration tests require preexisting infrastructure, e.g. IAM roles.
+
+See the `integration_config.yml.template` for the infrastructure details available and used by the tests. Your infrastructure setup process should produce an `integration_config.yml` file according to these values.
+
+- To see all of the integration tests aka targets:
+  ```bash
+  ansible-test integration --list-targets
+  ```
+- To run all of the integration tests:
+  ```bash
+  ansible-test integration --local
+  ```
+
+Once done with the integration tests, you will need to clean up any remaining CDP assets before tearing down the infrastructure (if needed).
+```bash
+ansible-test integration --local disabled/teardown
+```

--- a/tests/integration/targets/environ/defaults/main.yml
+++ b/tests/integration/targets/environ/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/environ/tasks/main.yml
+++ b/tests/integration/targets/environ/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-# Copyright 2022 Cloudera, Inc. All Rights Reserved.
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,52 @@
 
 - name: Describe environment
   cloudera.cloud.env_info:
-    name: "{{ env_name }}"
+    name: "{{ cdp.environment }}"
   register: __env
 
-- debug:
-    var: __env
+- name: Test for Environment existence
+  ansible.builtin.assert:
+    that: __env.environments | length == 0
+    fail_msg: "Test environment already exists: {{ cdp.environment }}"
+
+- name: Create a new AWS environment
+  when: network.type == "aws"
+  cloudera.cloud.env:
+    name: "{{ cdp.environment }}"
+    cloud: "{{ network.type }}"
+    credential: "{{ cdp.xaccount_credential }}"
+    region: "{{ network.region }}"
+    public_key_id: "{{ ssh.name }}"
+    vpc_id: "{{ network.vpc }}"
+    subnet_ids: "{{ network.public_subnets | union(network.private_subnets) }}"
+    default_sg: "{{ security.default_group }}"
+    knox_sg: "{{ security.knox_group }}"
+    log_identity: "{{ identity.log_role }}"
+    log_location: "{{ storage.log_location }}"
+  register: __env
+
+- name: Test for Environment creation
+  ansible.builtin.assert:
+    that:
+      - __env.environment | length > 0
+  
+- name: Destroy the Environment
+  cloudera.cloud.env:
+    name: "{{ cdp.environment }}"
+    state: absent
+  register: __env
+
+- name: Test for Environment destruction
+  ansible.builtin.assert:
+    that:
+      - not __env.environment
+
+- name: Describe environment
+  cloudera.cloud.env_info:
+    name: "{{ cdp.environment }}"
+  register: __env
+
+- name: Test for Environment destruction
+  ansible.builtin.assert:
+    that: __env.environments | length == 0
+    fail_msg: "Test environment was not destroyed: {{ cdp.environment }}"

--- a/tests/integration/targets/setup_cred/aliases
+++ b/tests/integration/targets/setup_cred/aliases
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 skip/python2
-setup/once/setup_cred
-#needs/target/another
+hidden

--- a/tests/integration/targets/setup_cred/defaults/main.yml
+++ b/tests/integration/targets/setup_cred/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/setup_cred/tasks/main.yml
+++ b/tests/integration/targets/setup_cred/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+- name: Construct integration testing Credential
+  when: network.type == 'aws'
+  cloudera.cloud.env_cred:
+    name: "{{ cdp.xaccount_credential }}"
+    cloud: "{{ network.type }}"
+    role: "{{ identity.xaccount_role }}"
+    description: "Integration test for {{ cdp.environment }}"
+  register: __cred

--- a/tests/integration/targets/teardown/aliases
+++ b/tests/integration/targets/teardown/aliases
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 skip/python2
-setup/once/setup_cred
-#needs/target/another
+setup/once/teardown_cred
+disabled

--- a/tests/integration/targets/teardown/defaults/main.yml
+++ b/tests/integration/targets/teardown/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/teardown/tasks/main.yml
+++ b/tests/integration/targets/teardown/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/teardown_cred/aliases
+++ b/tests/integration/targets/teardown_cred/aliases
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 skip/python2
-setup/once/setup_cred
-#needs/target/another
+hidden

--- a/tests/integration/targets/teardown_cred/defaults/main.yml
+++ b/tests/integration/targets/teardown_cred/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/teardown_cred/meta/main.yml
+++ b/tests/integration/targets/teardown_cred/meta/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+dependencies:
+  - teardown_environ

--- a/tests/integration/targets/teardown_cred/tasks/main.yml
+++ b/tests/integration/targets/teardown_cred/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+- name: Destroy integration testing Credential
+  cloudera.cloud.env_cred:
+    name: "{{ cdp.xaccount_credential }}"
+    state: absent
+  register: __cred

--- a/tests/integration/targets/teardown_dl/aliases
+++ b/tests/integration/targets/teardown_dl/aliases
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 skip/python2
-setup/once/setup_cred
-#needs/target/another
+hidden

--- a/tests/integration/targets/teardown_dl/defaults/main.yml
+++ b/tests/integration/targets/teardown_dl/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/teardown_dl/tasks/main.yml
+++ b/tests/integration/targets/teardown_dl/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+- name: Destroy integration testing Datalake
+  cloudera.cloud.datalake:
+    name: "{{ cdp.datalake }}"
+    state: absent
+  register: __dl

--- a/tests/integration/targets/teardown_environ/aliases
+++ b/tests/integration/targets/teardown_environ/aliases
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 skip/python2
-setup/once/setup_cred
-#needs/target/another
+hidden

--- a/tests/integration/targets/teardown_environ/defaults/main.yml
+++ b/tests/integration/targets/teardown_environ/defaults/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-skip/python2
-setup/once/setup_cred
-#needs/target/another

--- a/tests/integration/targets/teardown_environ/meta/main.yml
+++ b/tests/integration/targets/teardown_environ/meta/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+dependencies:
+  - teardown_dl

--- a/tests/integration/targets/teardown_environ/tasks/main.yml
+++ b/tests/integration/targets/teardown_environ/tasks/main.yml
@@ -1,3 +1,5 @@
+---
+
 # Copyright 2023 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-skip/python2
-setup/once/setup_cred
-#needs/target/another
+- name: Destroy integration testing Environment
+  cloudera.cloud.env:
+    name: "{{ cdp.environment }}"
+    state: absent
+  register: __env


### PR DESCRIPTION
Includes a TESTING.md doc for `units` and `integration` testing via `ansible-test`