### PR TITLE
Add Ansible Galaxy imports

### DIFF
--- a/.github/workflows/publish_galaxy.yml
+++ b/.github/workflows/publish_galaxy.yml
@@ -1,0 +1,35 @@
+---
+
+  # Copyright 2024 Cloudera, Inc. All Rights Reserved.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #      http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+name: Publish to Ansible Galaxy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  galaxy_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Publish collection to Ansible Galaxy
+        uses: ansible/ansible-publish-action@v1.0.0
+        with:
+          api_key: "${{ secrets.GALAXY_API_KEY }}"

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python and caching
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: 'pip'
@@ -77,7 +77,7 @@ jobs:
           echo $PR_NUMBER > ./pr/pr_number
         
       - name: Upload the PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -75,9 +75,16 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      
+        
       - name: Upload the PR number
         uses: actions/upload-artifact@v3
         with:
           name: pr_number
           path: pr/
+
+  import-galaxy:
+    needs: validate
+    permissions:
+      contents: read
+    name: Import collection with Galaxy importer
+    uses: ansible-community/github-action-test-galaxy-import/.github/workflows/test-galaxy-import.yml@main

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,10 @@ namespace:  cloudera
 name:       cloud
 version:    2.3.1
 readme:     README.md
-authors:    []
+authors:
+  - Jim Enright @jenright
+  - Ronald Suplina @rsuplina
+  - Webster Mudge @wmudge
 
 description: >
   A set of modules and other artifacts for interacting with the services and endpoints
@@ -30,6 +33,8 @@ tags:
 - azure
 - aws
 - gcp
+- data_service
+- data_hub
 
 dependencies: {}
 


### PR DESCRIPTION
Add a step to PR validate to test import and add a new workflow on release publication to push to the Galaxy site using a Github `secret`.