### PR TITLE
API docs update

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,6 @@
 ---
 
-# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ on:
 jobs:
   build-ansible-docs:
     name: Build Ansible Docs
-    uses: cloudera-labs/github-actions/.github/workflows/construct-ansible-docs.yml@v1
+    uses: cloudera-labs/github-actions/.github/workflows/construct-ansible-docs.yml@main
     with:
       pages-upload: true
       directory-upload: true
@@ -45,6 +45,6 @@ jobs:
     steps:
       - name: Deploy Github Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
         with:
           artifact_name: github-pages

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cd docsbuild
 pip install ansible-core https://github.com/cloudera-labs/antsibull-docs/archive/cldr-docsite.tar.gz
 
 # Install the collection's build dependencies
-pip install requirements.txt
+pip install -r requirements.txt
 
 # Then run the build script
 ./build.sh

--- a/docsbuild/conf.py
+++ b/docsbuild/conf.py
@@ -17,7 +17,7 @@
 # http://www.sphinx-doc.org/en/master/config
 
 project = "cloudera.cloud"
-copyright = "Cloudera, Inc."
+copyright = "2024 Cloudera, Inc."
 
 title = "Cloudera Labs"
 html_short_title = "Cloudera Labs"

--- a/docsbuild/requirements.txt
+++ b/docsbuild/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+sphinx-ansible-theme

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@
 
 namespace:  cloudera
 name:       cloud
-version:    2.5.0
+version:    2.5.1
 readme:     README.md
 authors:
   - Jim Enright @jenright


### PR DESCRIPTION
Update to use the latest `antsibull-doc` tooling and remove deprecated Github actions.