### PR TITLE
Update VW and Data Viz api parameters

### DIFF
--- a/plugins/modules/dw_data_visualization.py
+++ b/plugins/modules/dw_data_visualization.py
@@ -90,11 +90,11 @@ options:
   image_version:
     description: Version of the Cloudera Data Visualization.
     type: str
-  template_name:
+  resource_template:
     description: The name of the available resource template to use for the Cloudera Data Visualization.
     type: str
     aliases:
-      - resource_template
+      - template_name
   wait:
     description:
       - Flag to enable internal polling to wait for the Data Visualization Instance to achieve the declared state.
@@ -194,7 +194,7 @@ class DwCluster(CdpModule):
         self.name = self._get_param("name")
         self.config = self._get_param("config")
         self.state = self._get_param("state")
-        self.template_name = self._get_param("template_name")
+        self.resource_template = self._get_param("resource_template")
         self.image_version = self._get_param("image_version")
         self.wait = self._get_param("wait")
         self.delay = self._get_param("delay")
@@ -329,7 +329,7 @@ class DwCluster(CdpModule):
                         cluster_id=self.cluster["id"],
                         name=self.name,
                         config=self.config,
-                        resource_template=self.template_name,
+                        resource_template=self.resource_template,
                         image_version=self.image_version,
                     )
                     if self.wait:
@@ -358,7 +358,7 @@ def main():
             id=dict(type="str"),
             name=dict(type="str"),
             config=dict(type="dict"),
-            template_name=dict(type="str", aliases=["resource_template"]),
+            resource_template=dict(type="str", aliases=["template_name"]),
             image_version=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             wait=dict(type="bool", default=True),

--- a/plugins/modules/dw_data_visualization.py
+++ b/plugins/modules/dw_data_visualization.py
@@ -91,8 +91,10 @@ options:
     description: Version of the Cloudera Data Visualization.
     type: str
   template_name:
-    description: The template size for the Cloudera Data Visualization.
+    description: The name of the available resource template to use for the Cloudera Data Visualization.
     type: str
+    aliases:
+      - resource_template
   wait:
     description:
       - Flag to enable internal polling to wait for the Data Visualization Instance to achieve the declared state.
@@ -327,7 +329,7 @@ class DwCluster(CdpModule):
                         cluster_id=self.cluster["id"],
                         name=self.name,
                         config=self.config,
-                        template_name=self.template_name,
+                        resource_template=self.template_name,
                         image_version=self.image_version,
                     )
                     if self.wait:
@@ -356,7 +358,7 @@ def main():
             id=dict(type="str"),
             name=dict(type="str"),
             config=dict(type="dict"),
-            template_name=dict(type="str"),
+            template_name=dict(type="str", aliases=["resource_template"]),
             image_version=dict(type="str"),
             state=dict(type="str", choices=["present", "absent"], default="present"),
             wait=dict(type="bool", default=True),

--- a/plugins/modules/dw_virtual_warehouse.py
+++ b/plugins/modules/dw_virtual_warehouse.py
@@ -71,7 +71,7 @@ options:
       - Required if C(state=present)
     type: str
   template:
-    description: 
+    description:
       - The name of deployment T-shirt size to use.
       - This will determine the number of nodes.
     type: str
@@ -81,7 +81,7 @@ options:
       - medium
       - large
     aliases:
-      - tshirt_size      
+      - tshirt_size
   autoscaling:
     description:
       - Auto-scaling configuration for a Virtual Warehouse
@@ -604,7 +604,11 @@ def main():
             catalog_id=dict(type="str", aliases=["dbc_id"]),
             type=dict(type="str"),
             name=dict(type="str"),
-            template=dict(type="str", choices=["xsmall", "small", "medium", "large"], aliases=["tshirt_size"]),
+            template=dict(
+                type="str",
+                choices=["xsmall", "small", "medium", "large"],
+                aliases=["tshirt_size"],
+            ),
             autoscaling=dict(
                 type="dict",
                 options=dict(

--- a/plugins/modules/dw_virtual_warehouse.py
+++ b/plugins/modules/dw_virtual_warehouse.py
@@ -70,9 +70,9 @@ options:
       - The name of the Virtual Warehouse.
       - Required if C(state=present)
     type: str
-  template:
+  tshirt_size:
     description:
-      - The name of deployment T-shirt size to use.
+      - The name of deployment T-shirt size, i.e. the deployment template, to use.
       - This will determine the number of nodes.
     type: str
     choices:
@@ -81,7 +81,7 @@ options:
       - medium
       - large
     aliases:
-      - tshirt_size
+      - template
   autoscaling:
     description:
       - Auto-scaling configuration for a Virtual Warehouse
@@ -287,7 +287,7 @@ EXAMPLES = r"""
     cluster_id: example-cluster-id
     name: example-virtual-warehouse
     type: hive
-    template: xsmall
+    tshirt_size: xsmall
     autoscaling:
       min_nodes: 3
       max_nodes: 19
@@ -301,7 +301,7 @@ EXAMPLES = r"""
     cluster_id: example-cluster-id
     name: example-virtual-warehouse
     type: "hive"
-    template: "xsmall"
+    tshirt_size: "xsmall"
     enable_sso: true
     ldap_groups: ['group1','group2','group3']
     common_configs:
@@ -403,7 +403,7 @@ class DwVirtualWarehouse(CdpModule):
         self.dbc_id = self._get_param("catalog_id")
         self.type = self._get_param("type")
         self.name = self._get_param("name")
-        self.template = self._get_param("template")
+        self.tshirt_size = self._get_param("tshirt_size")
         self.common_configs = self._get_param("common_configs")
         self.application_configs = self._get_param("application_configs")
         self.ldap_groups = self._get_param("ldap_groups")
@@ -550,7 +550,7 @@ class DwVirtualWarehouse(CdpModule):
                         dbc_id=self.dbc_id,
                         vw_type=self.type,
                         name=self.name,
-                        tshirt_size=self.template,
+                        tshirt_size=self.tshirt_size,
                         autoscaling_min_cluster=self.autoscaling_min_nodes,
                         autoscaling_max_cluster=self.autoscaling_max_nodes,
                         autoscaling_auto_suspend_timeout_seconds=self.autoscaling_auto_suspend_timeout_seconds,
@@ -604,10 +604,10 @@ def main():
             catalog_id=dict(type="str", aliases=["dbc_id"]),
             type=dict(type="str"),
             name=dict(type="str"),
-            template=dict(
+            tshirt_size=dict(
                 type="str",
                 choices=["xsmall", "small", "medium", "large"],
-                aliases=["tshirt_size"],
+                aliases=["template"],
             ),
             autoscaling=dict(
                 type="dict",

--- a/plugins/modules/dw_virtual_warehouse.py
+++ b/plugins/modules/dw_virtual_warehouse.py
@@ -71,13 +71,17 @@ options:
       - Required if C(state=present)
     type: str
   template:
-    description: The name of deployment template for the Virtual Warehouse
+    description: 
+      - The name of deployment T-shirt size to use.
+      - This will determine the number of nodes.
     type: str
     choices:
       - xsmall
       - small
       - medium
       - large
+    aliases:
+      - tshirt_size      
   autoscaling:
     description:
       - Auto-scaling configuration for a Virtual Warehouse
@@ -546,7 +550,7 @@ class DwVirtualWarehouse(CdpModule):
                         dbc_id=self.dbc_id,
                         vw_type=self.type,
                         name=self.name,
-                        template=self.template,
+                        tshirt_size=self.template,
                         autoscaling_min_cluster=self.autoscaling_min_nodes,
                         autoscaling_max_cluster=self.autoscaling_max_nodes,
                         autoscaling_auto_suspend_timeout_seconds=self.autoscaling_auto_suspend_timeout_seconds,
@@ -600,7 +604,7 @@ def main():
             catalog_id=dict(type="str", aliases=["dbc_id"]),
             type=dict(type="str"),
             name=dict(type="str"),
-            template=dict(type="str", choices=["xsmall", "small", "medium", "large"]),
+            template=dict(type="str", choices=["xsmall", "small", "medium", "large"], aliases=["tshirt_size"]),
             autoscaling=dict(
                 type="dict",
                 options=dict(


### PR DESCRIPTION
Following the release of version 0.9.128 of the CDP CLI and API some CDW related parameters have been renamed:
* In Virtual Warehouse creation `template` has been renamed to `tShirtSize`. [API Docs Link](https://cloudera.github.io/cdp-dev-docs/api-docs/dw/index.html#_createvwrequest)
* In Data Visualisation creation `templateName` has been renamed to `resourceTemplate`. [API Docs Link](https://cloudera.github.io/cdp-dev-docs/api-docs/dw/index.html#_createdatavisualizationrequest)

This PR handles the parameter renaming in the cloudera.cloud Ansible collection. Requires https://github.com/cloudera-labs/cdpy/pull/106