### PR TITLE
Add namespace parameter to ml workbench module

### DIFF
--- a/plugins/module_utils/cdp_common.py
+++ b/plugins/module_utils/cdp_common.py
@@ -47,7 +47,7 @@ class CdpModule(object):
     def __init__(self, module):
         # Set common parameters
         self.module = module
-        self.tls = self._get_param("verify_tls", False)
+        self.verify_tls = self._get_param("verify_tls", False)
         self.debug = self._get_param("debug", False)
         self.strict = self._get_param("strict", False)
         self.agent_header = self._get_param("agent_header", "ClouderaFoundry")
@@ -61,7 +61,7 @@ class CdpModule(object):
         # Client Wrapper
         self.cdpy = Cdpy(
             debug=self.debug,
-            tls_verify=self.tls,
+            tls_verify=self.verify_tls,
             strict_errors=self.strict,
             error_handler=self._cdp_module_throw_error,
             warning_handler=self._cdp_module_throw_warning,
@@ -103,7 +103,7 @@ class CdpModule(object):
         """Default Ansible Module spec values for convenience"""
         return dict(
             **spec,
-            verify_tls=dict(required=False, type="bool", default=True, aliases=["tls"]),
+            verify_tls=dict(required=False, type="bool", default=True),
             debug=dict(
                 required=False,
                 type="bool",

--- a/plugins/modules/ml.py
+++ b/plugins/modules/ml.py
@@ -116,6 +116,12 @@ options:
     aliases:
       - existing_database
       - database_config
+  namespace:
+    description:
+      - The namespace to use for the workspace.
+      - Applicable to I(Private Cloud) deployments only.
+    type: str
+    required: False
   nfs:
     description:
       - An existing NFS mount (hostname and desired path).
@@ -584,6 +590,7 @@ class MLWorkspace(CdpModule):
         self.governance = self._get_param("governance")
         self.metrics = self._get_param("metrics")
         self.database = self._get_param("database")
+        self.namespace = self._get_param("namespace")
         self.nfs = self._get_param("nfs")
         self.nfs_version = self._get_param("nfs_version")
         self.ip_addresses = self._get_param("ip_addresses")
@@ -676,6 +683,7 @@ class MLWorkspace(CdpModule):
                         enableGovernance=self.governance,
                         enableModelMetrics=self.metrics,
                         existingDatabaseConfig=self.database,
+                        namespace=self.namespace,
                         existingNFS=self.nfs,
                         nfsVersion=self.nfs_version,
                         loadBalancerIPWhitelists=self.ip_addresses,
@@ -783,6 +791,7 @@ def main():
                 ),
                 aliases=["existing_database", "database_config"],
             ),
+            namespace=dict(required=False, type="str"),
             nfs=dict(required=False, type="str", aliases=["existing_nfs"]),
             nfs_version=dict(required=False, type="str"),
             k8s_request=dict(


### PR DESCRIPTION
Also removes the tls alias for verify_tls in cdp_common.py.

Note that this change requires the namespace parameter to be exposed in the [create ai workbench api](https://cloudera.github.io/cdp-dev-docs/api-docs/ml/index.html#_createworkspacerequest).