### PR TITLE
Update df_service_info module

### DIFF
--- a/plugins/modules/df_service_info.py
+++ b/plugins/modules/df_service_info.py
@@ -201,6 +201,7 @@ class DFServiceInfo(ServicesModule):
             self.services = [
                 self.df_client.describe_service(svc["crn"]).get("service", {})
                 for svc in response.get("services", [])
+                if svc.get("status", {}).get("state") not in CdpDfClient.DISABLED_STATES
             ]
             return
 

--- a/tests/unit/plugins/modules/df_service_info/test_df_service_info_int.py
+++ b/tests/unit/plugins/modules/df_service_info/test_df_service_info_int.py
@@ -87,7 +87,6 @@ def test_df_service_info_list_by_name(module_args, df_client):
 
     assert result.value.changed is False
     assert hasattr(result.value, "services")
-    assert len(result.value.services) >= 1
 
 
 def test_df_service_info_by_crn(module_args, df_client):
@@ -114,7 +113,6 @@ def test_df_service_info_by_crn(module_args, df_client):
 
     assert result.value.changed is False
     assert hasattr(result.value, "services")
-    assert len(result.value.services) >= 1
 
 
 def test_df_service_info_by_env_crn(module_args, df_client):
@@ -141,7 +139,6 @@ def test_df_service_info_by_env_crn(module_args, df_client):
 
     assert result.value.changed is False
     assert hasattr(result.value, "services")
-    assert len(result.value.services) >= 1
 
 
 def test_df_service_info_nonexistent(module_args):


### PR DESCRIPTION
Disabled Dataflow service is only visible if "Persist History" is enabled during the disabling of the service.
Describe DF Service API cannot be used to retrieve details about a disabled service.