### PR TITLE
Add iam_user module for CDP IAM user management

### DIFF
--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -839,7 +839,6 @@ class CdpIamClient:
 
         return changed
 
-
     def assign_user_role(self, user_id: str, role: str) -> Dict[str, Any]:
         """
         Assign a role to a user.

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -527,6 +527,417 @@ class CdpIamClient:
             json_data=json_data,
         )
 
+    # ========================================================================
+    # User Management Methods
+    # ========================================================================
+
+    def create_user(
+        self,
+        email: str,
+        identity_provider_user_id: str,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        saml_provider_name: Optional[str] = None,
+        groups: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create a user in CDP.
+
+        Args:
+            email: The email address for the user (display purposes only)
+            identity_provider_user_id: The identity provider user ID that matches the NameId in SAML response
+            first_name: The user's first name
+            last_name: The user's last name
+            saml_provider_name: The name or CRN of the SAML provider for login.
+                               If not provided, the default identity provider will be used.
+            groups: List of groups the user belongs to (will be created if they don't exist)
+
+        Returns:
+            Response containing the created user information
+        """
+        # If saml_provider_name not provided, use default identity provider
+        if saml_provider_name is None:
+            default_idp = self.get_default_identity_provider()
+            saml_provider_name = default_idp.get("crn", {})
+
+        json_data: Dict[str, Any] = {
+            "email": email,
+            "identityProviderUserId": identity_provider_user_id,
+        }
+
+        if first_name is not None:
+            json_data["firstName"] = first_name
+        if last_name is not None:
+            json_data["lastName"] = last_name
+        if saml_provider_name is not None:
+            json_data["samlProviderName"] = saml_provider_name
+        if groups is not None:
+            json_data["groups"] = groups
+
+        return self.api_client.post(
+            "/api/v1/iam/createUser",
+            json_data=json_data,
+        )
+
+    def delete_user(self, user_id: str) -> Dict[str, Any]:
+        """
+        Delete a user and all associated resources.
+
+        This includes deleting all associated access keys, unassigning all roles and resource roles,
+        and removing the user from all groups.
+
+        Args:
+            user_id: The user ID or CRN to delete
+
+        Returns:
+            Response containing information about deleted resources
+        """
+        json_data: Dict[str, Any] = {
+            "userId": user_id,
+        }
+
+        return self.api_client.post(
+            "/api/v1/iam/deleteUser",
+            json_data=json_data,
+        )
+
+    def update_user(
+        self,
+        user_id: str,
+        active: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """
+        Update a user.
+
+        Args:
+            user_id: The user ID or CRN to update
+            active: Set user active state (True to activate, False to deactivate)
+
+        Returns:
+            Response containing updated user information
+        """
+        json_data: Dict[str, Any] = {
+            "user": user_id,
+        }
+
+        if active is not None:
+            json_data["active"] = active
+
+        return self.api_client.post(
+            "/api/v1/iam/updateUser",
+            json_data=json_data,
+        )
+
+    def get_user_details(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get complete user information including roles and resource assignments.
+
+        This method makes multiple API calls to assemble a comprehensive user profile:
+        - Basic user information (from get_user)
+        - Assigned roles
+        - Assigned resource roles
+        - Group memberships
+
+        Args:
+            user_id: The user ID or CRN
+
+        Returns:
+            Complete user information dict, or None if user doesn't exist
+        """
+        try:
+            user_info = self.get_user(user_id=user_id)
+            if not user_info:
+                return None
+
+            roles_response = self.list_user_assigned_roles(user=user_id)
+            roles = roles_response.get("roleCrns", [])
+
+            resource_roles_response = self.list_user_assigned_resource_roles(
+                user=user_id,
+            )
+            resource_assignments = resource_roles_response.get(
+                "resourceAssignments",
+                [],
+            )
+
+            groups_response = self.list_groups_for_user(user_id=user_id)
+            groups = groups_response.get("groupCrns", [])
+
+            return {
+                "userId": user_info.get("userId"),
+                "crn": user_info.get("crn"),
+                "email": user_info.get("email"),
+                "firstName": user_info.get("firstName"),
+                "lastName": user_info.get("lastName"),
+                "status": user_info.get("status"),
+                "workloadUsername": user_info.get("workloadUsername"),
+                "creationDate": user_info.get("creationDate"),
+                "roles": roles,
+                "resourceAssignments": resource_assignments,
+                "groups": groups,
+            }
+        except Exception:
+            return None
+
+    def get_user_details_by_email(self, email: str) -> Optional[Dict[str, Any]]:
+        """
+        Get complete user information by email address.
+
+        This method searches for a user by email and returns complete user details.
+        Useful for idempotency when user_id is not available.
+
+        Args:
+            email: The email address of the user to find
+
+        Returns:
+            Complete user information dict, or None if user doesn't exist
+        """
+        try:
+            users_response = self.list_users()
+            users = users_response.get("users", [])
+
+            for user in users:
+                if user.get("email") == email:
+                    user_id = user.get("userId")
+                    return self.get_user_details(user_id=user_id)
+            return None
+        except Exception:
+            return None
+
+    def manage_user_groups(
+        self,
+        user_id: str,
+        current_groups: List[str],
+        desired_groups: List[str],
+        purge: bool = False,
+    ) -> bool:
+        """
+        Manage user group memberships.
+
+        Args:
+            user_id: The user ID or CRN
+            current_groups: List of current group CRNs (from list_groups_for_user)
+            desired_groups: List of desired group names
+            purge: If True, remove user from groups not in desired list
+
+        Returns:
+            True if changes were made, False otherwise
+        """
+        changed = False
+
+        # Fetch actual group names for current group CRNs
+        current_group_names = set()
+        if current_groups:
+            groups_response = self.list_groups(group_names=current_groups)
+            for group in groups_response.get("groups", []):
+                group_name = group.get("groupName")
+                if group_name:
+                    current_group_names.add(group_name)
+
+        desired_group_names = set(desired_groups)
+
+        if purge:
+            groups_to_remove = current_group_names - desired_group_names
+            for group_name in groups_to_remove:
+                self.remove_user_from_group(user_id=user_id, group_name=group_name)
+                changed = True
+
+        groups_to_add = desired_group_names - current_group_names
+        for group_name in groups_to_add:
+            # Check if group exists, create if it doesn't
+            if not self.get_group_details(group_name):
+                self.create_group(group_name=group_name)
+            self.add_user_to_group(user_id=user_id, group_name=group_name)
+            changed = True
+
+        return changed
+
+    def manage_user_roles(
+        self,
+        user_id: str,
+        current_roles: List[str],
+        desired_roles: List[str],
+        purge: bool = False,
+    ) -> bool:
+        """
+        Manage user role assignments.
+
+        Args:
+            user_id: The user ID or CRN
+            current_roles: List of current role CRNs
+            desired_roles: List of desired role CRNs
+            purge: If True, remove roles not in desired list
+
+        Returns:
+            True if changes were made, False otherwise
+        """
+        changed = False
+
+        if purge:
+            roles_to_remove = [
+                role for role in current_roles if role not in desired_roles
+            ]
+            for role in roles_to_remove:
+                self.unassign_user_role(user_id=user_id, role=role)
+                changed = True
+
+        roles_to_add = [role for role in desired_roles if role not in current_roles]
+        for role in roles_to_add:
+            self.assign_user_role(user_id=user_id, role=role)
+            changed = True
+
+        return changed
+
+    def manage_user_resource_roles(
+        self,
+        user_id: str,
+        current_assignments: List[Dict[str, str]],
+        desired_assignments: List[Dict[str, str]],
+        purge: bool = False,
+    ) -> bool:
+        """
+        Manage user resource role assignments.
+
+        Args:
+            user_id: The user ID or CRN
+            current_assignments: List of current resource role assignments
+            desired_assignments: List of desired resource role assignments
+            purge: If True, remove assignments not in desired list
+
+        Returns:
+            True if changes were made, False otherwise
+        """
+        changed = False
+
+        # Normalize current assignments for comparison
+        def normalize_assignment(assignment: Dict[str, str]) -> tuple:
+            resource = assignment.get("resource") or assignment.get("resourceCrn")
+            role = assignment.get("role") or assignment.get("resourceRoleCrn")
+            return (resource, role)
+
+        current_set = {normalize_assignment(a) for a in current_assignments}
+        desired_set = {normalize_assignment(a) for a in desired_assignments}
+
+        if purge:
+            assignments_to_remove = current_set - desired_set
+            for resource_crn, resource_role_crn in assignments_to_remove:
+                self.unassign_user_resource_role(
+                    user_id=user_id,
+                    resource_crn=resource_crn,
+                    resource_role_crn=resource_role_crn,
+                )
+                changed = True
+
+        assignments_to_add = desired_set - current_set
+        for resource_crn, resource_role_crn in assignments_to_add:
+            self.assign_user_resource_role(
+                user_id=user_id,
+                resource_crn=resource_crn,
+                resource_role_crn=resource_role_crn,
+            )
+            changed = True
+
+        return changed
+
+
+    def assign_user_role(self, user_id: str, role: str) -> Dict[str, Any]:
+        """
+        Assign a role to a user.
+
+        Args:
+            user_id: The user ID or CRN
+            role: The role CRN to assign
+
+        Returns:
+            Response from the API
+        """
+        json_data: Dict[str, Any] = {
+            "user": user_id,
+            "role": role,
+        }
+
+        return self.api_client.post(
+            "/api/v1/iam/assignUserRole",
+            json_data=json_data,
+        )
+
+    def assign_user_resource_role(
+        self,
+        user_id: str,
+        resource_crn: str,
+        resource_role_crn: str,
+    ) -> Dict[str, Any]:
+        """
+        Assign a resource role to a user.
+
+        Args:
+            user_id: The user ID or CRN
+            resource_crn: The resource CRN
+            resource_role_crn: The resource role CRN to assign
+
+        Returns:
+            Response from the API
+        """
+        json_data: Dict[str, Any] = {
+            "user": user_id,
+            "resourceCrn": resource_crn,
+            "resourceRoleCrn": resource_role_crn,
+        }
+
+        return self.api_client.post(
+            "/api/v1/iam/assignUserResourceRole",
+            json_data=json_data,
+        )
+
+    def unassign_user_role(self, user_id: str, role: str) -> Dict[str, Any]:
+        """
+        Unassign a role from a user.
+
+        Args:
+            user_id: The user ID or CRN
+            role: The role CRN to unassign
+
+        Returns:
+            Response from the API
+        """
+        json_data: Dict[str, Any] = {
+            "user": user_id,
+            "role": role,
+        }
+
+        return self.api_client.post(
+            "/api/v1/iam/unassignUserRole",
+            json_data=json_data,
+        )
+
+    def unassign_user_resource_role(
+        self,
+        user_id: str,
+        resource_crn: str,
+        resource_role_crn: str,
+    ) -> Dict[str, Any]:
+        """
+        Unassign a resource role from a user.
+
+        Args:
+            user_id: The user ID or CRN
+            resource_crn: The resource CRN
+            resource_role_crn: The resource role CRN to unassign
+
+        Returns:
+            Response from the API
+        """
+        json_data: Dict[str, Any] = {
+            "user": user_id,
+            "resourceCrn": resource_crn,
+            "resourceRoleCrn": resource_role_crn,
+        }
+
+        return self.api_client.post(
+            "/api/v1/iam/unassignUserResourceRole",
+            json_data=json_data,
+        )
+
     @CdpClient.paginated()
     def list_machine_user_assigned_roles(
         self,
@@ -1453,4 +1864,48 @@ class CdpIamClient:
         return self.api_client.post(
             "/api/v1/iam/generateWorkloadAuthToken",
             json_data=json_data,
+        )
+    @CdpClient.paginated()
+    def list_saml_providers(
+        self,
+        saml_provider_names: Optional[List[str]] = None,
+        pageToken: Optional[str] = None,
+        pageSize: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        List SAML providers with automatic pagination.
+
+        Args:
+            saml_provider_names: Optional list of SAML provider names or CRNs to filter by
+            pageToken: Token for pagination (automatically handled by decorator)
+            pageSize: Page size for pagination (automatically handled by decorator)
+
+        Returns:
+            Response with automatic pagination handling containing SAML providers list
+        """
+        json_data: Dict[str, Any] = {}
+
+        if saml_provider_names is not None:
+            json_data["samlProviderNames"] = saml_provider_names
+
+        if pageToken is not None:
+            json_data["startingToken"] = pageToken
+        if pageSize is not None:
+            json_data["pageSize"] = pageSize
+
+        return self.api_client.post(
+            "/api/v1/iam/listSamlProviders",
+            json_data=json_data,
+        )
+
+    def get_default_identity_provider(self) -> Dict[str, Any]:
+        """
+        Get the default identity provider for the account.
+
+        Returns:
+            Response containing the default identity provider information
+        """
+        return self.api_client.post(
+            "/api/v1/iam/getDefaultIdentityProvider",
+            json_data={},
         )

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -1896,6 +1896,7 @@ class CdpIamClient:
             "/api/v1/iam/generateWorkloadAuthToken",
             json_data=json_data,
         )
+
     @CdpClient.paginated()
     def list_saml_providers(
         self,

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -937,6 +937,38 @@ class CdpIamClient:
             json_data=json_data,
         )
 
+    def set_workload_password(
+        self,
+        password: str,
+        actor_crn: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Set the workload password for an actor.
+
+        This will be the actor's password in all Environments they have access to,
+        including Environments they are given access to after setting the password.
+        The password plaintext is not kept.
+
+        Args:
+            password: The password value to set
+            actor_crn: The CRN of the user or machine user for whom the password will be set.
+                      If not provided, it defaults to the user making the request.
+
+        Returns:
+            Response from the API
+        """
+        json_data: Dict[str, Any] = {
+            "password": password,
+        }
+
+        if actor_crn is not None:
+            json_data["actorCrn"] = actor_crn
+
+        return self.api_client.post(
+            "/api/v1/iam/setWorkloadPassword",
+            json_data=json_data,
+        )
+
     @CdpClient.paginated()
     def list_machine_user_assigned_roles(
         self,

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 
 from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
     CdpClient,
+    CdpError,
 )
 
 
@@ -538,10 +539,13 @@ class CdpIamClient:
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
         saml_provider_name: Optional[str] = None,
-        groups: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Create a user in CDP.
+
+        Note: This method intentionally does not support the 'groups' parameter
+        to avoid the side effect of group creation. Group memberships should be
+        managed separately after user creation using manage_user_groups().
 
         Args:
             email: The email address for the user (display purposes only)
@@ -550,7 +554,6 @@ class CdpIamClient:
             last_name: The user's last name
             saml_provider_name: The name or CRN of the SAML provider for login.
                                If not provided, the default identity provider will be used.
-            groups: List of groups the user belongs to (will be created if they don't exist)
 
         Returns:
             Response containing the created user information
@@ -571,8 +574,6 @@ class CdpIamClient:
             json_data["lastName"] = last_name
         if saml_provider_name is not None:
             json_data["samlProviderName"] = saml_provider_name
-        if groups is not None:
-            json_data["groups"] = groups
 
         return self.api_client.post(
             "/api/v1/iam/createUser",
@@ -714,6 +715,9 @@ class CdpIamClient:
         """
         Manage user group memberships.
 
+        Note: This method will NOT create groups automatically. Groups must exist
+        before adding users to them. Use the iam_group module to create groups.
+
         Args:
             user_id: The user ID or CRN
             current_groups: List of current group CRNs (from list_groups_for_user)
@@ -722,6 +726,9 @@ class CdpIamClient:
 
         Returns:
             True if changes were made, False otherwise
+
+        Raises:
+            CdpError: If a desired group does not exist
         """
         changed = False
 
@@ -744,9 +751,13 @@ class CdpIamClient:
 
         groups_to_add = desired_group_names - current_group_names
         for group_name in groups_to_add:
-            # Check if group exists, create if it doesn't
+            # Check if group exists, raise error if it doesn't
             if not self.get_group_details(group_name):
-                self.create_group(group_name=group_name)
+                raise CdpError(
+                    f"Group '{group_name}' does not exist. "
+                    f"Please create the group using the iam_group module before adding users to it.",
+                    status=404,
+                )
             self.add_user_to_group(user_id=user_id, group_name=group_name)
             changed = True
 

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -25,35 +25,6 @@ from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
     CdpError,
 )
 
-# Read-only/system-managed fields that should be excluded from diffs
-# These fields are not user-controllable and are managed by CDP
-USER_READONLY_FIELDS = [
-    "userId",  # System-generated unique identifier
-    "crn",  # System-generated CDP Resource Name
-    "creationDate",  # Timestamp when user was created
-    "accountAdmin",  # System-managed admin flag
-    "status",  # System-managed status (ACTIVE, CONTROL_PLANE_LOCKED_OUT, etc.)
-    "workloadUsername",  # Auto-generated username for workload clusters
-    "workloadPasswordDetails",  # Read-only password metadata (isPasswordSet, expirationDate, etc.)
-    "lastInteractiveLogin",  # System-tracked login timestamp
-    "identityProviderCrn",  # System-assigned identity provider reference
-]
-
-# Read-only/system-managed fields for groups
-GROUP_READONLY_FIELDS = [
-    "crn",  # System-generated CDP Resource Name
-    "creationDate",  # Timestamp when group was created
-]
-
-# Read-only/system-managed fields for machine users
-MACHINE_USER_READONLY_FIELDS = [
-    "crn",  # System-generated CDP Resource Name
-    "creationDate",  # Timestamp when machine user was created
-    "status",  # System-managed status
-    "workloadUsername",  # Auto-generated username for workload clusters
-    "workloadPasswordDetails",  # Read-only password metadata
-]
-
 
 class CdpIamClient:
     """CDP IAM API client."""

--- a/plugins/module_utils/cdp_iam.py
+++ b/plugins/module_utils/cdp_iam.py
@@ -25,6 +25,35 @@ from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
     CdpError,
 )
 
+# Read-only/system-managed fields that should be excluded from diffs
+# These fields are not user-controllable and are managed by CDP
+USER_READONLY_FIELDS = [
+    "userId",  # System-generated unique identifier
+    "crn",  # System-generated CDP Resource Name
+    "creationDate",  # Timestamp when user was created
+    "accountAdmin",  # System-managed admin flag
+    "status",  # System-managed status (ACTIVE, CONTROL_PLANE_LOCKED_OUT, etc.)
+    "workloadUsername",  # Auto-generated username for workload clusters
+    "workloadPasswordDetails",  # Read-only password metadata (isPasswordSet, expirationDate, etc.)
+    "lastInteractiveLogin",  # System-tracked login timestamp
+    "identityProviderCrn",  # System-assigned identity provider reference
+]
+
+# Read-only/system-managed fields for groups
+GROUP_READONLY_FIELDS = [
+    "crn",  # System-generated CDP Resource Name
+    "creationDate",  # Timestamp when group was created
+]
+
+# Read-only/system-managed fields for machine users
+MACHINE_USER_READONLY_FIELDS = [
+    "crn",  # System-generated CDP Resource Name
+    "creationDate",  # Timestamp when machine user was created
+    "status",  # System-managed status
+    "workloadUsername",  # Auto-generated username for workload clusters
+    "workloadPasswordDetails",  # Read-only password metadata
+]
+
 
 class CdpIamClient:
     """CDP IAM API client."""
@@ -37,6 +66,58 @@ class CdpIamClient:
             api_client: CdpClient instance for managing HTTP method calls
         """
         self.api_client = api_client
+
+    @staticmethod
+    def get_user_diff_exclude_keys() -> List[str]:
+        """
+        Get list of user fields to exclude from diff calculations.
+
+        These fields are read-only or system-managed and should not appear
+        in Ansible diff output as they cannot be modified by users.
+
+        Returns:
+            List of field names to exclude from diffs (in snake_case format)
+        """
+        return [
+            "user_id",
+            "crn",
+            "creation_date",
+            "account_admin",
+            "status",
+            "workload_username",
+            "workload_password_details",
+            "last_interactive_login",
+            "identity_provider_crn",
+        ]
+
+    @staticmethod
+    def get_group_diff_exclude_keys() -> List[str]:
+        """
+        Get list of group fields to exclude from diff calculations.
+
+        Returns:
+            List of field names to exclude from diffs (in snake_case format)
+        """
+        return [
+            "crn",
+            "creation_date",
+        ]
+
+    @staticmethod
+    def get_machine_user_diff_exclude_keys() -> List[str]:
+        """
+        Get list of machine user fields to exclude from diff calculations.
+
+        Returns:
+            List of field names to exclude from diffs (in snake_case format)
+        """
+        return [
+            "crn",
+            "creation_date",
+            "status",
+            "workload_username",
+            "workload_password_details",
+        ]
 
     def _is_machine_user(self, user_crn: str) -> bool:
         """Check if a user CRN represents a machine user."""

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -22,7 +22,7 @@ import abc
 import io
 import logging
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.parameters import env_fallback
@@ -35,6 +35,123 @@ from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
 
 
 LOG_FORMAT = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def diff_dict(
+    prev: Optional[Dict[str, Any]],
+    next: Optional[Dict[str, Any]],
+    exclude_keys: Optional[List[str]] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Compare two dictionaries and return their differences.
+
+    Recursively compares two dictionaries field by field and returns
+    a tuple of dictionaries containing the old and new values for fields that differ.
+    Supports nested dictionaries, lists, and primitive types.
+
+    Args:
+        prev: The previous dictionary to compare from (can be None).
+        next: The next dictionary to compare to (can be None).
+        exclude_keys: Optional list of keys to exclude from comparison (e.g., read-only fields).
+
+    Returns:
+        A tuple of two dictionaries (old_values, new_values) containing only the fields
+        that differ between the dictionaries. Nested differences are represented as nested
+        dictionaries. Empty dictionaries are returned if dictionaries are identical.
+
+    Example:
+        >>> old = {"name": "Alice", "age": 30, "city": "NYC"}
+        >>> new = {"name": "Alice", "age": 31, "city": "NYC"}
+        >>> old_diff, new_diff = diff_dict(old, new)
+        >>> print(old_diff)
+        {'age': 30}
+        >>> print(new_diff)
+        {'age': 31}
+    """
+    exclude_keys = exclude_keys or []
+
+    def _diff_recursive(prev_val: Any, new_val: Any) -> Tuple[Any, Any, bool]:
+        """
+        Recursively compare values and return (prev_val, new_val, has_diff).
+
+        Returns:
+            Tuple of (prev_value, new_value, has_difference)
+        """
+        # If both are None, no difference
+        if prev_val is None and new_val is None:
+            return None, None, False
+
+        # If one is None and the other isn't, there's a difference
+        if prev_val is None or new_val is None:
+            return prev_val, new_val, True
+
+        # If both are dictionaries, compare key by key
+        if isinstance(prev_val, dict) and isinstance(new_val, dict):
+            prev_diff = {}
+            new_diff = {}
+            has_diff = False
+
+            # Get all unique keys from both dictionaries
+            all_keys = set(prev_val.keys()) | set(new_val.keys())
+
+            for key in all_keys:
+                # Skip excluded keys
+                if key in exclude_keys:
+                    continue
+
+                prev_item = prev_val.get(key)
+                new_item = new_val.get(key)
+
+                prev_item_diff, new_item_diff, item_has_diff = _diff_recursive(
+                    prev_item,
+                    new_item,
+                )
+
+                if item_has_diff:
+                    prev_diff[key] = prev_item_diff
+                    new_diff[key] = new_item_diff
+                    has_diff = True
+
+            return prev_diff, new_diff, has_diff
+
+        # If both are lists, compare element by element
+        if isinstance(prev_val, list) and isinstance(new_val, list):
+            # For lists, we'll do a simple equality check
+            # More sophisticated list comparison can be added if needed
+            if len(prev_val) != len(new_val):
+                return prev_val, new_val, True
+
+            # Check if lists have different elements (order-independent for simplicity)
+            prev_set = set(str(x) for x in prev_val)
+            new_set = set(str(x) for x in new_val)
+
+            if prev_set != new_set:
+                return prev_val, new_val, True
+
+            return None, None, False
+
+        # For primitives and other types, direct comparison
+        if prev_val != new_val:
+            return prev_val, new_val, True
+
+        return None, None, False
+
+    # Handle None inputs
+    if prev is None and next is None:
+        return {}, {}
+
+    if prev is None:
+        return {}, next
+
+    if next is None:
+        return prev, {}
+
+    prev_diff, next_diff, _ = _diff_recursive(prev, next)
+
+    return (
+        prev_diff if isinstance(prev_diff, dict) else {},
+        next_diff if isinstance(next_diff, dict) else {},
+    )
 
 
 class ParametersMixin(abc.ABC):

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -87,8 +87,8 @@ def diff_dict(
 
         # If both are dictionaries, compare key by key
         if isinstance(prev_val, dict) and isinstance(new_val, dict):
-            prev_diff = {}
-            new_diff = {}
+            old_dict = {}
+            new_dict = {}
             has_diff = False
 
             # Get all unique keys from both dictionaries
@@ -99,42 +99,51 @@ def diff_dict(
                 if key in exclude_keys:
                     continue
 
-                prev_item = prev_val.get(key)
+                old_item = prev_val.get(key)
                 new_item = new_val.get(key)
 
-                prev_item_diff, new_item_diff, item_has_diff = _diff_recursive(
-                    prev_item,
+                old_result, new_result, item_has_diff = _diff_recursive(
+                    old_item,
                     new_item,
                 )
 
                 if item_has_diff:
-                    prev_diff[key] = prev_item_diff
-                    new_diff[key] = new_item_diff
+                    old_dict[key] = old_result
+                    new_dict[key] = new_result
                     has_diff = True
 
-            return prev_diff, new_diff, has_diff
+            if has_diff:
+                return old_dict, new_dict, True
+            return {}, {}, False
 
-        # If both are lists, compare element by element
+        # If both are lists, compare element by element recursively
         if isinstance(prev_val, list) and isinstance(new_val, list):
-            # For lists, we'll do a simple equality check
-            # More sophisticated list comparison can be added if needed
             if len(prev_val) != len(new_val):
                 return prev_val, new_val, True
 
-            # Check if lists have different elements (order-independent for simplicity)
-            prev_set = set(str(x) for x in prev_val)
-            new_set = set(str(x) for x in new_val)
+            old_list = []
+            new_list = []
+            has_diff = False
 
-            if prev_set != new_set:
-                return prev_val, new_val, True
+            for old_item, new_item in zip(prev_val, new_val):
+                old_result, new_result, item_diff = _diff_recursive(old_item, new_item)
+                if item_diff:
+                    old_list.append(old_result)
+                    new_list.append(new_result)
+                    has_diff = True
+                else:
+                    old_list.append(old_item)
+                    new_list.append(new_item)
 
-            return None, None, False
+            if has_diff:
+                return old_list, new_list, True
+            return [], [], False
 
         # For primitives and other types, direct comparison
         if prev_val != new_val:
             return prev_val, new_val, True
 
-        return None, None, False
+        return prev_val, new_val, False
 
     # Handle None inputs
     if prev is None and next is None:

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -354,7 +354,6 @@ class IAMUser(ServicesModule):
         elif self.user_id:
             existing_user = self.client.get_user_details(user_id=self.user_id)
 
-
         if self.state == "absent":
             if existing_user:
                 if not self.module.check_mode:
@@ -366,7 +365,7 @@ class IAMUser(ServicesModule):
             if not existing_user:
                 # Default identity_provider_user_id to email if not provided
                 idp_user_id = self.identity_provider_user_id or self.email
-                
+
                 if not self.module.check_mode:
                     response = self.client.create_user(
                         email=self.email,
@@ -378,10 +377,9 @@ class IAMUser(ServicesModule):
                     )
                     self.user = response.get("user", {})
                     existing_user = self.client.get_user_details(
-                        user_id=self.user.get("userId")
+                        user_id=self.user.get("userId"),
                     )
                 self.changed = True
-
 
             if existing_user and not self.module.check_mode:
 
@@ -417,7 +415,7 @@ class IAMUser(ServicesModule):
 
             if existing_user and self.changed and not self.module.check_mode:
                 existing_user = self.client.get_user_details(
-                    user_id=existing_user.get("userId")
+                    user_id=existing_user.get("userId"),
                 )
 
             if existing_user:

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -114,7 +114,6 @@ options:
       - This parameter is optional and only set if provided.
     type: str
     required: False
-    no_log: True
     aliases:
       - password
   state:
@@ -441,7 +440,7 @@ class IAMUser(ServicesModule):
                         self.changed = True
 
                 if self.workload_password is not None:
-                    tt=self.client.set_workload_password(
+                    self.client.set_workload_password(
                         password=self.workload_password,
                         actor_crn=existing_user.get("crn"),
                     )

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -1,0 +1,447 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: iam_user
+short_description: Create, update, or remove CDP IAM Users
+description:
+    - Create, update, and remove Cloudera Data Platform IAM Users.
+    - Manage user role and resource role assignments.
+author:
+  - "Ronald Suplina (@rsuplina)"
+version_added: "3.2.0"
+options:
+  email:
+    description:
+      - The email address for the user.
+      - Required when creating a new user (C(state=present)).
+      - Can be used to identify an existing user for updates or deletion.
+      - If both C(email) and C(user_id) are provided, C(email) takes precedence for lookup.
+    type: str
+    required: False
+  first_name:
+    description:
+      - The user's first name.
+    type: str
+    required: False
+  groups:
+    description:
+      - List of groups the user belongs to.
+      - Groups will be created if they don't exist.
+    type: list
+    elements: str
+    required: False
+  identity_provider_user_id:
+    description:
+      - The identity provider user ID for the user.
+      - This ID must match the NameId attribute value in the SAML response.
+      - If not provided, defaults to the email address (common for most SAML providers).
+      - Only used when creating a new user.
+    type: str
+    required: False
+    aliases:
+      - idp_user_id
+  last_name:
+    description:
+      - The user's last name.
+    type: str
+    required: False
+  purge:
+    description:
+      - Flag to replace C(roles) and C(resource_roles) with their specified values.
+      - If True, any roles or resource roles not specified will be removed.
+    type: bool
+    required: False
+    default: False
+  resource_roles:
+    description:
+      - A list of resource role assignments.
+    type: list
+    required: False
+    elements: dict
+    suboptions:
+      resource:
+        description:
+          - The resource CRN for the rights assignment.
+        type: str
+        required: True
+        aliases:
+          - resourceCrn
+          - resource_crn
+      role:
+        description:
+          - The resource role CRN to be assigned.
+        type: str
+        required: True
+        aliases:
+          - resourceRoleCrn
+          - resource_role_crn
+  roles:
+    description:
+      - A single role or list of roles assigned to the user.
+      - The role must be identified by its full CRN.
+    type: list
+    elements: str
+    required: False
+  saml_provider_name:
+    description:
+      - The name or CRN of the SAML provider the user will use for login.
+      - If not provided, the default identity provider will be used automatically.
+    type: str
+    required: False
+    aliases:
+      - saml_provider
+  state:
+    description:
+      - The state of the user.
+    type: str
+    required: False
+    default: present
+    choices:
+      - present
+      - absent
+  user_id:
+    description:
+      - The user ID or CRN of the user to manage.
+      - Can be used to identify an existing user for updates or deletion.
+      - Either C(user_id) or C(email) must be provided.
+      - If both C(email) and C(user_id) are provided, C(email) takes precedence for lookup.
+    type: str
+    required: False
+    aliases:
+      - user
+extends_documentation_fragment:
+  - cloudera.cloud.cdp_client
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details.
+
+# Create a user (identity_provider_user_id defaults to email)
+- cloudera.cloud.iam_user:
+    email: user@example.com
+    first_name: John
+    last_name: Doe
+    saml_provider_name: my-saml-provider
+
+# Create a user with explicit identity provider user ID
+- cloudera.cloud.iam_user:
+    email: user@example.com
+    identity_provider_user_id: user123
+    first_name: John
+    last_name: Doe
+    saml_provider_name: my-saml-provider
+
+# Create a user and assign to groups
+- cloudera.cloud.iam_user:
+    email: user@example.com
+    groups:
+      - developers
+      - admins
+
+# Delete a user by user_id
+- cloudera.cloud.iam_user:
+    state: absent
+    user_id: crn:cdp:iam:us-west-1:altus:user:example-user-id
+
+# Delete a user by email
+- cloudera.cloud.iam_user:
+    state: absent
+    email: user@example.com
+
+# Assign roles to an existing user
+- cloudera.cloud.iam_user:
+    user_id: user@example.com
+    roles:
+      - crn:cdp:iam:us-west-1:altus:role:PowerUser
+
+# Assign resource roles to a user
+- cloudera.cloud.iam_user:
+    user_id: user@example.com
+    resource_roles:
+      - resource: crn:cdp:environments:us-west-1:altus:environment:dev-env
+        role: crn:cdp:iam:us-west-1:altus:resourceRole:EnvironmentUser
+
+# Replace resource roles for a user
+- cloudera.cloud.iam_user:
+    user_id: user@example.com
+    resource_roles:
+      - resource: crn:cdp:environments:us-west-1:altus:environment:prod-env
+        role: crn:cdp:iam:us-west-1:altus:resourceRole:EnvironmentAdmin
+    purge: true
+
+"""
+
+RETURN = r"""
+user:
+  description: The information about the User
+  type: dict
+  returned: always
+  contains:
+    creation_date:
+      description: The date when this user record was created.
+      returned: on success
+      type: str
+      sample: 2020-07-06T12:24:05.531000+00:00
+    crn:
+      description: The CRN of the user.
+      returned: on success
+      type: str
+    email:
+      description: The user's email address.
+      returned: on success
+      type: str
+      sample: user@example.com
+    first_name:
+      description: The user's first name.
+      returned: on success
+      type: str
+    last_name:
+      description: The user's last name.
+      returned: on success
+      type: str
+    status:
+      description: The status of the user.
+      returned: on success
+      type: str
+      sample: ACTIVE
+    workload_username:
+      description: The username used in all the workload clusters of the user.
+      returned: on success
+      type: str
+    groups:
+      description: List of Group CRNs the user belongs to.
+      returned: on success
+      type: list
+      elements: str
+    roles:
+      description: List of Role CRNs assigned to the user.
+      returned: on success
+      type: list
+      elements: str
+    resource_assignments:
+      description: List of Resource-to-Role assignments that are associated with the user.
+      returned: on success
+      type: list
+      elements: dict
+      contains:
+        resource_crn:
+          description: The CRN of the resource granted the rights of the role.
+          returned: on success
+          type: str
+        resource_role_crn:
+          description: The CRN of the resource role.
+          returned: on success
+          type: str
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+"""
+
+from typing import Any, Dict
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.cloudera.cloud.plugins.module_utils.common import (
+    ServicesModule,
+)
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_iam import (
+    CdpIamClient,
+)
+
+
+class IAMUser(ServicesModule):
+    def __init__(self):
+        super().__init__(
+            argument_spec=dict(
+                state=dict(
+                    required=False,
+                    type="str",
+                    choices=["present", "absent"],
+                    default="present",
+                ),
+                user_id=dict(required=False, type="str", aliases=["user"]),
+                email=dict(required=False, type="str"),
+                identity_provider_user_id=dict(
+                    required=False,
+                    type="str",
+                    aliases=["idp_user_id"],
+                ),
+                first_name=dict(required=False, type="str"),
+                last_name=dict(required=False, type="str"),
+                saml_provider_name=dict(
+                    required=False,
+                    type="str",
+                    aliases=["saml_provider"],
+                ),
+                groups=dict(required=False, type="list", elements="str"),
+                roles=dict(required=False, type="list", elements="str"),
+                resource_roles=dict(
+                    required=False,
+                    type="list",
+                    elements="dict",
+                    options=dict(
+                        resource=dict(
+                            required=True,
+                            type="str",
+                            aliases=["resource_crn"],
+                        ),
+                        role=dict(
+                            required=True,
+                            type="str",
+                            aliases=["resource_role_crn", "resourceRoleCrn"],
+                        ),
+                    ),
+                ),
+                purge=dict(required=False, type="bool", default=False),
+            ),
+            required_one_of=[
+                ["user_id", "email"],
+            ],
+            required_if=[
+                ("state", "present", ["email"]),
+            ],
+            supports_check_mode=True,
+        )
+
+        # Set parameters
+        self.state = self.get_param("state")
+        self.user_id = self.get_param("user_id")
+        self.email = self.get_param("email")
+        self.identity_provider_user_id = self.get_param("identity_provider_user_id")
+        self.first_name = self.get_param("first_name")
+        self.last_name = self.get_param("last_name")
+        self.saml_provider_name = self.get_param("saml_provider_name")
+        self.groups = self.get_param("groups")
+        self.roles = self.get_param("roles")
+        self.resource_roles = self.get_param("resource_roles")
+        self.purge = self.get_param("purge")
+
+        # Initialize return values
+        self.user = {}
+        self.changed = False
+
+        # Initialize client
+        self.client = CdpIamClient(api_client=self.api_client)
+
+    def process(self):
+        existing_user = None
+
+        if self.email:
+            existing_user = self.client.get_user_details_by_email(email=self.email)
+            if existing_user:
+                self.user_id = existing_user.get("userId")
+        elif self.user_id:
+            existing_user = self.client.get_user_details(user_id=self.user_id)
+
+
+        if self.state == "absent":
+            if existing_user:
+                if not self.module.check_mode:
+                    self.client.delete_user(user_id=self.user_id)
+                self.changed = True
+
+        elif self.state == "present":
+
+            if not existing_user:
+                # Default identity_provider_user_id to email if not provided
+                idp_user_id = self.identity_provider_user_id or self.email
+                
+                if not self.module.check_mode:
+                    response = self.client.create_user(
+                        email=self.email,
+                        first_name=self.first_name,
+                        groups=self.groups,
+                        identity_provider_user_id=idp_user_id,
+                        last_name=self.last_name,
+                        saml_provider_name=self.saml_provider_name,
+                    )
+                    self.user = response.get("user", {})
+                    existing_user = self.client.get_user_details(
+                        user_id=self.user.get("userId")
+                    )
+                self.changed = True
+
+
+            if existing_user and not self.module.check_mode:
+
+                if self.groups is not None or self.purge:
+                    if self.client.manage_user_groups(
+                        user_id=existing_user.get("userId"),
+                        current_groups=existing_user.get("groups", []),
+                        desired_groups=self.groups or [],
+                        purge=self.purge,
+                    ):
+                        self.changed = True
+
+                if self.roles is not None or self.purge:
+                    if self.client.manage_user_roles(
+                        user_id=existing_user.get("userId"),
+                        current_roles=existing_user.get("roles", []),
+                        desired_roles=self.roles or [],
+                        purge=self.purge,
+                    ):
+                        self.changed = True
+
+                if self.resource_roles is not None or self.purge:
+                    if self.client.manage_user_resource_roles(
+                        user_id=existing_user.get("userId"),
+                        current_assignments=existing_user.get(
+                            "resourceAssignments",
+                            [],
+                        ),
+                        desired_assignments=(self.resource_roles or []),
+                        purge=self.purge,
+                    ):
+                        self.changed = True
+
+            if existing_user and self.changed and not self.module.check_mode:
+                existing_user = self.client.get_user_details(
+                    user_id=existing_user.get("userId")
+                )
+
+            if existing_user:
+                self.user = existing_user
+
+        self.user = camel_dict_to_snake_dict(self.user)
+
+
+def main():
+    result = IAMUser()
+
+    output: Dict[str, Any] = dict(
+        changed=result.changed,
+        user=result.user,
+    )
+
+    if result.debug_log:
+        output.update(
+            sdk_out=result.log_out,
+            sdk_out_lines=result.log_lines,
+        )
+
+    result.module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -28,9 +28,9 @@ options:
   email:
     description:
       - The email address for the user.
-      - Required when creating a new user (C(state=present)).
+      - Required when creating a new user (O(state=present)).
       - Can be used to identify an existing user for updates or deletion.
-      - If both C(email) and C(user_id) are provided, C(email) takes precedence for lookup.
+      - If both O(email) and O(user_id) are provided, O(email) takes precedence for lookup.
     type: str
     required: False
   first_name:
@@ -62,7 +62,7 @@ options:
     required: False
   purge:
     description:
-      - Flag to replace C(roles) and C(resource_roles) with their specified values.
+      - Flag to replace O(roles) and O(resource_roles) with their specified values.
       - If True, any roles or resource roles not specified will be removed.
     type: bool
     required: False
@@ -110,7 +110,7 @@ options:
       - The workload password for the user.
       - This will be the user's password in all Environments they have access to.
       - The password plaintext is not stored.
-      - Only applicable when creating or updating a user (C(state=present)).
+      - Only applicable when creating or updating a user (O(state=present)).
       - This parameter is optional and only set if provided.
     type: str
     required: False
@@ -129,8 +129,8 @@ options:
     description:
       - The user ID or CRN of the user to manage.
       - Can be used to identify an existing user for updates or deletion.
-      - Either C(user_id) or C(email) must be provided.
-      - If both C(email) and C(user_id) are provided, C(email) takes precedence for lookup.
+      - Either O(user_id) or O(email) must be provided.
+      - If both O(email) and O(user_id) are provided, O(email) takes precedence for lookup.
     type: str
     required: False
     aliases:
@@ -144,7 +144,7 @@ EXAMPLES = r"""
 
 # Create a user (identity_provider_user_id defaults to email)
 - cloudera.cloud.iam_user:
-    email: user@example.cCom1
+    email: user@example.com
     first_name: John
     last_name: Doe
     saml_provider_name: my-saml-provider

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -41,7 +41,8 @@ options:
   groups:
     description:
       - List of groups the user belongs to.
-      - Groups will be created if they don't exist.
+      - Groups must already exist before adding users to them.
+      - Use the M(cloudera.cloud.iam_group) module to create groups first.
     type: list
     elements: str
     required: False
@@ -157,7 +158,7 @@ EXAMPLES = r"""
     last_name: Doe
     saml_provider_name: my-saml-provider
 
-# Create a user and assign to groups
+# Create a user and assign to existing groups (groups must exist first)
 - cloudera.cloud.iam_user:
     email: user@example.com
     groups:
@@ -396,7 +397,6 @@ class IAMUser(ServicesModule):
                     response = self.client.create_user(
                         email=self.email,
                         first_name=self.first_name,
-                        groups=self.groups,
                         identity_provider_user_id=idp_user_id,
                         last_name=self.last_name,
                         saml_provider_name=self.saml_provider_name,

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -284,6 +284,7 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 
 from ansible_collections.cloudera.cloud.plugins.module_utils.common import (
     ServicesModule,
+    diff_dict,
 )
 from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_iam import (
     CdpIamClient,
@@ -367,6 +368,7 @@ class IAMUser(ServicesModule):
         # Initialize return values
         self.user = {}
         self.changed = False
+        self.diff = {}
 
         # Initialize client
         self.client = CdpIamClient(api_client=self.api_client)
@@ -383,15 +385,42 @@ class IAMUser(ServicesModule):
 
         if self.state == "absent":
             if existing_user:
+                if self.module._diff:
+                    self.diff = {
+                        "before": camel_dict_to_snake_dict(existing_user),
+                        "after": {},
+                    }
+
                 if not self.module.check_mode:
                     self.client.delete_user(user_id=self.user_id)
                 self.changed = True
 
         elif self.state == "present":
+            user_created = False  # Track if we created the user in this execution
 
             if not existing_user:
                 # Default identity_provider_user_id to email if not provided
                 idp_user_id = self.identity_provider_user_id or self.email
+
+                expected_user = {
+                    "email": self.email,
+                }
+                if self.first_name:
+                    expected_user["first_name"] = self.first_name
+                if self.last_name:
+                    expected_user["last_name"] = self.last_name
+                if self.groups:
+                    expected_user["groups"] = self.groups
+                if self.roles:
+                    expected_user["roles"] = self.roles
+                if self.resource_roles:
+                    expected_user["resource_assignments"] = self.resource_roles
+
+                if self.module._diff:
+                    self.diff = {
+                        "before": {},
+                        "after": expected_user,
+                    }
 
                 if not self.module.check_mode:
                     response = self.client.create_user(
@@ -405,9 +434,53 @@ class IAMUser(ServicesModule):
                     existing_user = self.client.get_user_details(
                         user_id=self.user.get("userId"),
                     )
+                    user_created = True  # Mark that we created the user
                 self.changed = True
 
-            if existing_user and not self.module.check_mode:
+            # Handle post-creation role/group management for newly created users
+            if existing_user and not self.module.check_mode and user_created:
+                # Add roles/groups to newly created user without recalculating diff
+                if self.groups is not None or self.purge:
+                    self.client.manage_user_groups(
+                        user_id=existing_user.get("userId"),
+                        current_groups=existing_user.get("groups", []),
+                        desired_groups=self.groups or [],
+                        purge=self.purge,
+                    )
+
+                if self.roles is not None or self.purge:
+                    self.client.manage_user_roles(
+                        user_id=existing_user.get("userId"),
+                        current_roles=existing_user.get("roles", []),
+                        desired_roles=self.roles or [],
+                        purge=self.purge,
+                    )
+
+                if self.resource_roles is not None or self.purge:
+                    self.client.manage_user_resource_roles(
+                        user_id=existing_user.get("userId"),
+                        current_assignments=existing_user.get(
+                            "resourceAssignments",
+                            [],
+                        ),
+                        desired_assignments=(self.resource_roles or []),
+                        purge=self.purge,
+                    )
+
+                if self.workload_password is not None:
+                    self.client.set_workload_password(
+                        password=self.workload_password,
+                        actor_crn=existing_user.get("crn"),
+                    )
+
+                # Fetch final user state for return value
+                existing_user = self.client.get_user_details(
+                    user_id=existing_user.get("userId"),
+                )
+
+            if existing_user and not self.module.check_mode and not user_created:
+                # Store the original state for diff comparison
+                original_user = dict(existing_user)
 
                 if self.groups is not None or self.purge:
                     if self.client.manage_user_groups(
@@ -446,10 +519,78 @@ class IAMUser(ServicesModule):
                     )
                     self.changed = True
 
-            if existing_user and self.changed and not self.module.check_mode:
-                existing_user = self.client.get_user_details(
-                    user_id=existing_user.get("userId"),
+                # Get the updated user state
+                if self.changed:
+                    existing_user = self.client.get_user_details(
+                        user_id=existing_user.get("userId"),
+                    )
+
+                    # Generate diff if requested
+                    if self.module._diff:
+                        # Exclude read-only/system fields from diff
+                        exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
+
+                        prev_diff, next_diff = diff_dict(
+                            camel_dict_to_snake_dict(original_user),
+                            camel_dict_to_snake_dict(existing_user),
+                            exclude_keys=exclude_keys,
+                        )
+
+                        if prev_diff or next_diff:
+                            self.diff = {
+                                "before": prev_diff,
+                                "after": next_diff,
+                            }
+
+            # For check mode with existing user, calculate what would change
+            elif existing_user and self.module.check_mode and not user_created:
+                # Build expected state by applying desired changes
+                expected_user = dict(existing_user)
+
+                if self.groups is not None:
+                    expected_user["groups"] = (
+                        self.groups
+                        if self.purge
+                        else list(set(existing_user.get("groups", []) + self.groups))
+                    )
+                elif self.purge:
+                    expected_user["groups"] = []
+
+                if self.roles is not None:
+                    expected_user["roles"] = (
+                        self.roles
+                        if self.purge
+                        else list(set(existing_user.get("roles", []) + self.roles))
+                    )
+                elif self.purge:
+                    expected_user["roles"] = []
+
+                if self.resource_roles is not None:
+                    expected_user["resourceAssignments"] = (
+                        self.resource_roles
+                        if self.purge
+                        else existing_user.get("resourceAssignments", [])
+                        + self.resource_roles
+                    )
+                elif self.purge:
+                    expected_user["resourceAssignments"] = []
+
+                exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
+
+                prev_diff, next_diff = diff_dict(
+                    camel_dict_to_snake_dict(existing_user),
+                    camel_dict_to_snake_dict(expected_user),
+                    exclude_keys=exclude_keys,
                 )
+
+                if prev_diff or next_diff or self.workload_password is not None:
+                    self.changed = True
+
+                    if self.module._diff and (prev_diff or next_diff):
+                        self.diff = {
+                            "before": prev_diff,
+                            "after": next_diff,
+                        }
 
             if existing_user:
                 self.user = existing_user
@@ -464,6 +605,9 @@ def main():
         changed=result.changed,
         user=result.user,
     )
+
+    if result.diff:
+        output.update(diff=result.diff)
 
     if result.debug_log:
         output.update(

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -373,15 +373,16 @@ class IAMUser(ServicesModule):
         # Initialize client
         self.client = CdpIamClient(api_client=self.api_client)
 
-    def process(self):
-        existing_user = None
-
+    def _find_existing_user(self):
         if self.email:
-            existing_user = self.client.get_user_details_by_email(email=self.email)
-            if existing_user:
-                self.user_id = existing_user.get("userId")
-        elif self.user_id:
-            existing_user = self.client.get_user_details(user_id=self.user_id)
+            user = self.client.get_user_details_by_email(email=self.email)
+            if user:
+                self.user_id = user.get("userId")
+            return user
+        return self.client.get_user_details(user_id=self.user_id)
+
+    def process(self):
+        existing_user = self._find_existing_user()
 
         if self.state == "absent":
             if existing_user:
@@ -390,37 +391,27 @@ class IAMUser(ServicesModule):
                         "before": camel_dict_to_snake_dict(existing_user),
                         "after": {},
                     }
-
                 if not self.module.check_mode:
                     self.client.delete_user(user_id=self.user_id)
                 self.changed = True
 
         elif self.state == "present":
-            user_created = False  # Track if we created the user in this execution
-
             if not existing_user:
-                # Default identity_provider_user_id to email if not provided
                 idp_user_id = self.identity_provider_user_id or self.email
 
-                expected_user = {
-                    "email": self.email,
-                }
-                if self.first_name:
-                    expected_user["first_name"] = self.first_name
-                if self.last_name:
-                    expected_user["last_name"] = self.last_name
-                if self.groups:
-                    expected_user["groups"] = self.groups
-                if self.roles:
-                    expected_user["roles"] = self.roles
-                if self.resource_roles:
-                    expected_user["resource_assignments"] = self.resource_roles
-
                 if self.module._diff:
-                    self.diff = {
-                        "before": {},
-                        "after": expected_user,
-                    }
+                    expected_user = {"email": self.email}
+                    if self.first_name:
+                        expected_user["first_name"] = self.first_name
+                    if self.last_name:
+                        expected_user["last_name"] = self.last_name
+                    if self.groups:
+                        expected_user["groups"] = self.groups
+                    if self.roles:
+                        expected_user["roles"] = self.roles
+                    if self.resource_roles:
+                        expected_user["resource_assignments"] = self.resource_roles
+                    self.diff = {"before": {}, "after": expected_user}
 
                 if not self.module.check_mode:
                     response = self.client.create_user(
@@ -430,170 +421,157 @@ class IAMUser(ServicesModule):
                         last_name=self.last_name,
                         saml_provider_name=self.saml_provider_name,
                     )
-                    self.user = response.get("user", {})
-                    existing_user = self.client.get_user_details(
-                        user_id=self.user.get("userId"),
-                    )
-                    user_created = True  # Mark that we created the user
-                self.changed = True
-
-            # Handle post-creation role/group management for newly created users
-            if existing_user and not self.module.check_mode and user_created:
-                # Add roles/groups to newly created user without recalculating diff
-                if self.groups is not None or self.purge:
-                    self.client.manage_user_groups(
-                        user_id=existing_user.get("userId"),
-                        current_groups=existing_user.get("groups", []),
-                        desired_groups=self.groups or [],
-                        purge=self.purge,
+                    created_user = self.client.get_user_details(
+                        user_id=response.get("user", {}).get("userId"),
                     )
 
-                if self.roles is not None or self.purge:
-                    self.client.manage_user_roles(
-                        user_id=existing_user.get("userId"),
-                        current_roles=existing_user.get("roles", []),
-                        desired_roles=self.roles or [],
-                        purge=self.purge,
-                    )
-
-                if self.resource_roles is not None or self.purge:
-                    self.client.manage_user_resource_roles(
-                        user_id=existing_user.get("userId"),
-                        current_assignments=existing_user.get(
-                            "resourceAssignments",
-                            [],
-                        ),
-                        desired_assignments=(self.resource_roles or []),
-                        purge=self.purge,
-                    )
-
-                if self.workload_password is not None:
-                    self.client.set_workload_password(
-                        password=self.workload_password,
-                        actor_crn=existing_user.get("crn"),
-                    )
-
-                # Fetch final user state for return value
-                existing_user = self.client.get_user_details(
-                    user_id=existing_user.get("userId"),
-                )
-
-            if existing_user and not self.module.check_mode and not user_created:
-                # Store the original state for diff comparison
-                original_user = dict(existing_user)
-
-                if self.groups is not None or self.purge:
-                    if self.client.manage_user_groups(
-                        user_id=existing_user.get("userId"),
-                        current_groups=existing_user.get("groups", []),
-                        desired_groups=self.groups or [],
-                        purge=self.purge,
-                    ):
-                        self.changed = True
-
-                if self.roles is not None or self.purge:
-                    if self.client.manage_user_roles(
-                        user_id=existing_user.get("userId"),
-                        current_roles=existing_user.get("roles", []),
-                        desired_roles=self.roles or [],
-                        purge=self.purge,
-                    ):
-                        self.changed = True
-
-                if self.resource_roles is not None or self.purge:
-                    if self.client.manage_user_resource_roles(
-                        user_id=existing_user.get("userId"),
-                        current_assignments=existing_user.get(
-                            "resourceAssignments",
-                            [],
-                        ),
-                        desired_assignments=(self.resource_roles or []),
-                        purge=self.purge,
-                    ):
-                        self.changed = True
-
-                if self.workload_password is not None:
-                    self.client.set_workload_password(
-                        password=self.workload_password,
-                        actor_crn=existing_user.get("crn"),
-                    )
-                    self.changed = True
-
-                # Get the updated user state
-                if self.changed:
-                    existing_user = self.client.get_user_details(
-                        user_id=existing_user.get("userId"),
-                    )
-
-                    # Generate diff if requested
-                    if self.module._diff:
-                        # Exclude read-only/system fields from diff
-                        exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
-
-                        prev_diff, next_diff = diff_dict(
-                            camel_dict_to_snake_dict(original_user),
-                            camel_dict_to_snake_dict(existing_user),
-                            exclude_keys=exclude_keys,
+                    if self.groups is not None or self.purge:
+                        self.client.manage_user_groups(
+                            user_id=created_user.get("userId"),
+                            current_groups=created_user.get("groups", []),
+                            desired_groups=self.groups or [],
+                            purge=self.purge,
                         )
 
-                        if prev_diff or next_diff:
-                            self.diff = {
-                                "before": prev_diff,
-                                "after": next_diff,
-                            }
+                    if self.roles is not None or self.purge:
+                        self.client.manage_user_roles(
+                            user_id=created_user.get("userId"),
+                            current_roles=created_user.get("roles", []),
+                            desired_roles=self.roles or [],
+                            purge=self.purge,
+                        )
 
-            # For check mode with existing user, calculate what would change
-            elif existing_user and self.module.check_mode and not user_created:
-                # Build expected state by applying desired changes
-                expected_user = dict(existing_user)
+                    if self.resource_roles is not None or self.purge:
+                        self.client.manage_user_resource_roles(
+                            user_id=created_user.get("userId"),
+                            current_assignments=created_user.get(
+                                "resourceAssignments",
+                                [],
+                            ),
+                            desired_assignments=self.resource_roles or [],
+                            purge=self.purge,
+                        )
 
-                if self.groups is not None:
-                    expected_user["groups"] = (
-                        self.groups
-                        if self.purge
-                        else list(set(existing_user.get("groups", []) + self.groups))
+                    if self.workload_password is not None:
+                        self.client.set_workload_password(
+                            password=self.workload_password,
+                            actor_crn=created_user.get("crn"),
+                        )
+
+                    self.user = self.client.get_user_details(
+                        user_id=created_user.get("userId"),
                     )
-                elif self.purge:
-                    expected_user["groups"] = []
 
-                if self.roles is not None:
-                    expected_user["roles"] = (
-                        self.roles
-                        if self.purge
-                        else list(set(existing_user.get("roles", []) + self.roles))
+                self.changed = True
+
+            else:
+                if self.module.check_mode:
+                    expected_user = dict(existing_user)
+
+                    if self.groups is not None:
+                        expected_user["groups"] = (
+                            self.groups
+                            if self.purge
+                            else list(
+                                set(existing_user.get("groups", []) + self.groups),
+                            )
+                        )
+                    elif self.purge:
+                        expected_user["groups"] = []
+
+                    if self.roles is not None:
+                        expected_user["roles"] = (
+                            self.roles
+                            if self.purge
+                            else list(
+                                set(existing_user.get("roles", []) + self.roles),
+                            )
+                        )
+                    elif self.purge:
+                        expected_user["roles"] = []
+
+                    if self.resource_roles is not None:
+                        expected_user["resourceAssignments"] = (
+                            self.resource_roles
+                            if self.purge
+                            else existing_user.get("resourceAssignments", [])
+                            + self.resource_roles
+                        )
+                    elif self.purge:
+                        expected_user["resourceAssignments"] = []
+
+                    exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
+                    prev_diff, next_diff = diff_dict(
+                        camel_dict_to_snake_dict(existing_user),
+                        camel_dict_to_snake_dict(expected_user),
+                        exclude_keys=exclude_keys,
                     )
-                elif self.purge:
-                    expected_user["roles"] = []
 
-                if self.resource_roles is not None:
-                    expected_user["resourceAssignments"] = (
-                        self.resource_roles
-                        if self.purge
-                        else existing_user.get("resourceAssignments", [])
-                        + self.resource_roles
-                    )
-                elif self.purge:
-                    expected_user["resourceAssignments"] = []
+                    if prev_diff or next_diff or self.workload_password is not None:
+                        self.changed = True
+                        if self.module._diff and (prev_diff or next_diff):
+                            self.diff = {"before": prev_diff, "after": next_diff}
 
-                exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
+                    self.user = existing_user
 
-                prev_diff, next_diff = diff_dict(
-                    camel_dict_to_snake_dict(existing_user),
-                    camel_dict_to_snake_dict(expected_user),
-                    exclude_keys=exclude_keys,
-                )
+                else:
+                    original_user = dict(existing_user)
 
-                if prev_diff or next_diff or self.workload_password is not None:
-                    self.changed = True
+                    if self.groups is not None or self.purge:
+                        if self.client.manage_user_groups(
+                            user_id=existing_user.get("userId"),
+                            current_groups=existing_user.get("groups", []),
+                            desired_groups=self.groups or [],
+                            purge=self.purge,
+                        ):
+                            self.changed = True
 
-                    if self.module._diff and (prev_diff or next_diff):
-                        self.diff = {
-                            "before": prev_diff,
-                            "after": next_diff,
-                        }
+                    if self.roles is not None or self.purge:
+                        if self.client.manage_user_roles(
+                            user_id=existing_user.get("userId"),
+                            current_roles=existing_user.get("roles", []),
+                            desired_roles=self.roles or [],
+                            purge=self.purge,
+                        ):
+                            self.changed = True
 
-            if existing_user:
-                self.user = existing_user
+                    if self.resource_roles is not None or self.purge:
+                        if self.client.manage_user_resource_roles(
+                            user_id=existing_user.get("userId"),
+                            current_assignments=existing_user.get(
+                                "resourceAssignments",
+                                [],
+                            ),
+                            desired_assignments=(self.resource_roles or []),
+                            purge=self.purge,
+                        ):
+                            self.changed = True
+
+                    if self.workload_password is not None:
+                        self.client.set_workload_password(
+                            password=self.workload_password,
+                            actor_crn=existing_user.get("crn"),
+                        )
+                        self.changed = True
+
+                    if self.changed:
+                        updated_user = self.client.get_user_details(
+                            user_id=existing_user.get("userId"),
+                        )
+
+                        if self.module._diff:
+                            exclude_keys = CdpIamClient.get_user_diff_exclude_keys()
+                            prev_diff, next_diff = diff_dict(
+                                camel_dict_to_snake_dict(original_user),
+                                camel_dict_to_snake_dict(updated_user),
+                                exclude_keys=exclude_keys,
+                            )
+                            if prev_diff or next_diff:
+                                self.diff = {"before": prev_diff, "after": next_diff}
+
+                        self.user = updated_user
+                    else:
+                        self.user = existing_user
 
         self.user = camel_dict_to_snake_dict(self.user)
 

--- a/tests/unit/plugins/module_utils/cdp_iam/test_iam_identity_providers.py
+++ b/tests/unit/plugins/module_utils/cdp_iam/test_iam_identity_providers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+import uuid
+
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_iam import (
+    CdpIamClient,
+)
+
+
+@pytest.mark.integration_api
+class TestIamUserClientIntegration:
+    """Integration tests for CdpIamClient user-related methods."""
+
+    def test_list_saml_providers(self, test_cdp_client):
+        """Test listing all SAML providers."""
+        
+        client = CdpIamClient(api_client=test_cdp_client)
+        result = client.list_saml_providers()
+        
+        assert "samlProviders" in result
+        assert isinstance(result["samlProviders"], list)
+
+
+    def test_get_default_identity_provider(self, test_cdp_client):
+        """Test getting the default identity provider."""
+        
+        client = CdpIamClient(api_client=test_cdp_client)
+        result = client.get_default_identity_provider()
+        
+        assert "crn" in result

--- a/tests/unit/plugins/module_utils/cdp_iam/test_iam_identity_providers.py
+++ b/tests/unit/plugins/module_utils/cdp_iam/test_iam_identity_providers.py
@@ -32,18 +32,17 @@ class TestIamUserClientIntegration:
 
     def test_list_saml_providers(self, test_cdp_client):
         """Test listing all SAML providers."""
-        
+
         client = CdpIamClient(api_client=test_cdp_client)
         result = client.list_saml_providers()
-        
+
         assert "samlProviders" in result
         assert isinstance(result["samlProviders"], list)
 
-
     def test_get_default_identity_provider(self, test_cdp_client):
         """Test getting the default identity provider."""
-        
+
         client = CdpIamClient(api_client=test_cdp_client)
         result = client.get_default_identity_provider()
-        
+
         assert "crn" in result

--- a/tests/unit/plugins/modules/iam_user/test_iam_user.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.cloudera.cloud.tests.unit import (
+    AnsibleFailJson,
+    AnsibleExitJson,
+)
+
+from ansible_collections.cloudera.cloud.plugins.modules import iam_user
+
+
+BASE_URL = "https://cloudera.internal/api"
+ACCESS_KEY = "test-access-key"
+PRIVATE_KEY = "test-private-key"
+FILE_ACCESS_KEY = "file-access-key"
+FILE_PRIVATE_KEY = "file-private-key"
+FILE_REGION = "default"
+
+USER_EMAIL = "test-user@example.com"
+USER_ID = "test-user-id"
+IDP_USER_ID = "test-idp-user-id"
+
+
+def test_iam_user_default(module_args):
+    """Test iam_user module with missing parameters."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+        },
+    )
+
+    # Expect the module to fail due to missing required parameter (need either user_id or email)
+    with pytest.raises(
+        AnsibleFailJson,
+        match="one of the following is required: user_id, email",
+    ):
+        iam_user.main()
+
+
+def test_iam_user_absent_missing_identifiers(module_args):
+    """Test iam_user module with state=absent but missing both user_id and email."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "state": "absent",
+        },
+    )
+
+    # Expect the module to fail due to missing required parameter (need either user_id or email)
+    with pytest.raises(
+        AnsibleFailJson, 
+        match="one of the following is required: user_id, email"
+    ):
+        iam_user.main()
+
+
+def test_iam_user_absent(module_args, mocker):
+    """Test iam_user module with state=absent."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "user_id": USER_EMAIL,
+            "state": "absent",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    client.get_user_details.return_value = {
+        "userId": USER_ID,
+        "email": USER_EMAIL,
+        "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+    }
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user == {}
+
+    # Verify CdpIamClient was called correctly
+    client.get_user_details.assert_called_once_with(user_id=USER_EMAIL)
+    client.delete_user.assert_called_once_with(user_id=USER_EMAIL)
+
+
+def test_iam_user_create_missing_email(module_args, mocker):
+    """Test iam_user module creating a new user without email fails."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "user_id": "some-user-id",  # Only user_id, no email
+            "state": "present",
+        },
+    )
+
+    # Expect the module to fail due to missing email (required_if validation)
+    with pytest.raises(
+        AnsibleFailJson,
+        match="state is present but all of the following are missing: email"
+    ):
+        iam_user.main()
+
+
+def test_iam_user_create(module_args, mocker):
+    """Test iam_user module creating a new user."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDP_USER_ID,
+            "first_name": "Test",
+            "last_name": "User",
+            "saml_provider_name": "mtaabich-test",
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    
+    # User doesn't exist initially (lookup by email)
+    client.get_user_details_by_email.return_value = None
+    
+    # After creation, get_user_details returns the created user
+    client.get_user_details.return_value = {
+        "userId": USER_ID,
+        "email": USER_EMAIL,
+        "firstName": "Test",
+        "lastName": "User",
+        "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        "roles": [],
+        "resourceAssignments": [],
+    }
+    
+    client.create_user.return_value = {
+        "user": {
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "firstName": "Test",
+            "lastName": "User",
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        }
+    }
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user["email"] == USER_EMAIL
+
+    # Verify CdpIamClient was called correctly
+    client.create_user.assert_called_once_with(
+        email=USER_EMAIL,
+        identity_provider_user_id=IDP_USER_ID,
+        first_name="Test",
+        last_name="User",
+        saml_provider_name="mtaabich-test",
+        groups=None,
+    )
+
+
+def test_iam_user_create_with_groups(module_args, mocker):
+    """Test iam_user module creating a new user with group assignments."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDP_USER_ID,
+            "groups": ["developers", "admins"],
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    
+    # User doesn't exist initially (lookup by email)
+    client.get_user_details_by_email.return_value = None
+    
+    # After creation, get_user_details returns the created user
+    client.get_user_details.return_value = {
+        "userId": USER_ID,
+        "email": USER_EMAIL,
+        "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        "roles": [],
+        "resourceAssignments": [],
+    }
+    
+    client.create_user.return_value = {
+        "user": {
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        }
+    }
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify CdpIamClient was called correctly
+    client.create_user.assert_called_once_with(
+        email=USER_EMAIL,
+        identity_provider_user_id=IDP_USER_ID,
+        first_name=None,
+        last_name=None,
+        saml_provider_name=None,
+        groups=["developers", "admins"],
+    )
+
+
+def test_iam_user_present_no_changes(module_args, mocker):
+    """Test iam_user module with state=present but no changes needed."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,  
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    client.get_user_details_by_email.return_value = {
+        "userId": USER_ID,
+        "email": USER_EMAIL,
+        "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        "roles": [],
+        "resourceAssignments": [],
+    }
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is False
+    assert result.value.user["email"] == USER_EMAIL
+
+    # Verify CdpIamClient was called correctly
+    client.get_user_details_by_email.assert_called_once_with(email=USER_EMAIL)
+
+
+def test_iam_user_assign_roles(module_args, mocker):
+    """Test iam_user module assigning roles to an existing user."""
+
+    role_crn = "crn:cdp:iam:us-west-1:altus:role:PowerUser"
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "roles": [role_crn],
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    
+    client.get_user_details_by_email.side_effect = [
+        {  # Initial state - no roles
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [],
+            "resourceAssignments": [],
+        },
+        {  # After role assignment
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [role_crn],
+            "resourceAssignments": [],
+        },
+    ]
+    
+    client.manage_user_roles.return_value = True
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify CdpIamClient was called correctly
+    client.manage_user_roles.assert_called_once_with(
+        user_id=USER_ID,  # Uses userId from the fetched user object
+        current_roles=[],
+        desired_roles=[role_crn],
+        purge=False,
+    )
+
+
+def test_iam_user_assign_resource_roles(module_args, mocker):
+    """Test iam_user module assigning resource roles to an existing user."""
+
+    resource_crn = "crn:cdp:environments:us-west-1:altus:environment:dev-env"
+    resource_role_crn = "crn:cdp:iam:us-west-1:altus:resourceRole:EnvironmentUser"
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,  
+            "resource_roles": [
+                {
+                    "resource": resource_crn,
+                    "role": resource_role_crn,
+                }
+            ],
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    
+    client.get_user_details_by_email.side_effect = [
+        {  # Initial state - no resource roles
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [],
+            "resourceAssignments": [],
+        },
+        {  # After resource role assignment
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [],
+            "resourceAssignments": [
+                {
+                    "resourceCrn": resource_crn,
+                    "resourceRoleCrn": resource_role_crn,
+                }
+            ],
+        },
+    ]
+    
+    client.manage_user_resource_roles.return_value = True
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify CdpIamClient was called correctly
+    client.manage_user_resource_roles.assert_called_once_with(
+        user_id=USER_ID,  # Uses userId from the fetched user object
+        current_assignments=[],
+        desired_assignments=[
+            {
+                "resource": resource_crn,
+                "role": resource_role_crn,
+            }
+        ],
+        purge=False,
+    )
+
+
+def test_iam_user_purge_roles(module_args, mocker):
+    """Test iam_user module purging roles from a user."""
+
+    existing_role = "crn:cdp:iam:us-west-1:altus:role:OldRole"
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,  
+            "roles": [],
+            "purge": True,
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+    
+    client.get_user_details_by_email.side_effect = [
+        {  # Initial state - has old role
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [existing_role],
+            "resourceAssignments": [],
+        },
+        {  # After purge - no roles
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+            "roles": [],
+            "resourceAssignments": [],
+        },
+    ]
+    
+    client.manage_user_roles.return_value = True
+
+    # Test module execution
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify CdpIamClient was called correctly
+    client.manage_user_roles.assert_called_once_with(
+        user_id=USER_ID,  # Uses userId from the fetched user object
+        current_roles=[existing_role],
+        desired_roles=[],
+        purge=True,
+    )

--- a/tests/unit/plugins/modules/iam_user/test_iam_user.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user.py
@@ -73,8 +73,8 @@ def test_iam_user_absent_missing_identifiers(module_args):
 
     # Expect the module to fail due to missing required parameter (need either user_id or email)
     with pytest.raises(
-        AnsibleFailJson, 
-        match="one of the following is required: user_id, email"
+        AnsibleFailJson,
+        match="one of the following is required: user_id, email",
     ):
         iam_user.main()
 
@@ -137,7 +137,7 @@ def test_iam_user_create_missing_email(module_args, mocker):
     # Expect the module to fail due to missing email (required_if validation)
     with pytest.raises(
         AnsibleFailJson,
-        match="state is present but all of the following are missing: email"
+        match="state is present but all of the following are missing: email",
     ):
         iam_user.main()
 
@@ -170,10 +170,10 @@ def test_iam_user_create(module_args, mocker):
         "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
         autospec=True,
     ).return_value
-    
+
     # User doesn't exist initially (lookup by email)
     client.get_user_details_by_email.return_value = None
-    
+
     # After creation, get_user_details returns the created user
     client.get_user_details.return_value = {
         "userId": USER_ID,
@@ -184,7 +184,7 @@ def test_iam_user_create(module_args, mocker):
         "roles": [],
         "resourceAssignments": [],
     }
-    
+
     client.create_user.return_value = {
         "user": {
             "userId": USER_ID,
@@ -192,7 +192,7 @@ def test_iam_user_create(module_args, mocker):
             "firstName": "Test",
             "lastName": "User",
             "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
-        }
+        },
     }
 
     # Test module execution
@@ -239,10 +239,10 @@ def test_iam_user_create_with_groups(module_args, mocker):
         "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
         autospec=True,
     ).return_value
-    
+
     # User doesn't exist initially (lookup by email)
     client.get_user_details_by_email.return_value = None
-    
+
     # After creation, get_user_details returns the created user
     client.get_user_details.return_value = {
         "userId": USER_ID,
@@ -251,13 +251,13 @@ def test_iam_user_create_with_groups(module_args, mocker):
         "roles": [],
         "resourceAssignments": [],
     }
-    
+
     client.create_user.return_value = {
         "user": {
             "userId": USER_ID,
             "email": USER_EMAIL,
             "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
-        }
+        },
     }
 
     # Test module execution
@@ -285,7 +285,7 @@ def test_iam_user_present_no_changes(module_args, mocker):
             "endpoint": BASE_URL,
             "access_key": ACCESS_KEY,
             "private_key": PRIVATE_KEY,
-            "email": USER_EMAIL,  
+            "email": USER_EMAIL,
             "state": "present",
         },
     )
@@ -347,7 +347,7 @@ def test_iam_user_assign_roles(module_args, mocker):
         "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
         autospec=True,
     ).return_value
-    
+
     client.get_user_details_by_email.side_effect = [
         {  # Initial state - no roles
             "userId": USER_ID,
@@ -364,7 +364,7 @@ def test_iam_user_assign_roles(module_args, mocker):
             "resourceAssignments": [],
         },
     ]
-    
+
     client.manage_user_roles.return_value = True
 
     # Test module execution
@@ -393,12 +393,12 @@ def test_iam_user_assign_resource_roles(module_args, mocker):
             "endpoint": BASE_URL,
             "access_key": ACCESS_KEY,
             "private_key": PRIVATE_KEY,
-            "email": USER_EMAIL,  
+            "email": USER_EMAIL,
             "resource_roles": [
                 {
                     "resource": resource_crn,
                     "role": resource_role_crn,
-                }
+                },
             ],
             "state": "present",
         },
@@ -415,7 +415,7 @@ def test_iam_user_assign_resource_roles(module_args, mocker):
         "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
         autospec=True,
     ).return_value
-    
+
     client.get_user_details_by_email.side_effect = [
         {  # Initial state - no resource roles
             "userId": USER_ID,
@@ -433,11 +433,11 @@ def test_iam_user_assign_resource_roles(module_args, mocker):
                 {
                     "resourceCrn": resource_crn,
                     "resourceRoleCrn": resource_role_crn,
-                }
+                },
             ],
         },
     ]
-    
+
     client.manage_user_resource_roles.return_value = True
 
     # Test module execution
@@ -454,7 +454,7 @@ def test_iam_user_assign_resource_roles(module_args, mocker):
             {
                 "resource": resource_crn,
                 "role": resource_role_crn,
-            }
+            },
         ],
         purge=False,
     )
@@ -470,7 +470,7 @@ def test_iam_user_purge_roles(module_args, mocker):
             "endpoint": BASE_URL,
             "access_key": ACCESS_KEY,
             "private_key": PRIVATE_KEY,
-            "email": USER_EMAIL,  
+            "email": USER_EMAIL,
             "roles": [],
             "purge": True,
             "state": "present",
@@ -488,7 +488,7 @@ def test_iam_user_purge_roles(module_args, mocker):
         "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
         autospec=True,
     ).return_value
-    
+
     client.get_user_details_by_email.side_effect = [
         {  # Initial state - has old role
             "userId": USER_ID,
@@ -505,7 +505,7 @@ def test_iam_user_purge_roles(module_args, mocker):
             "resourceAssignments": [],
         },
     ]
-    
+
     client.manage_user_roles.return_value = True
 
     # Test module execution

--- a/tests/unit/plugins/modules/iam_user/test_iam_user.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user.py
@@ -651,4 +651,3 @@ def test_iam_user_create_with_workload_password(module_args, mocker):
         password="SecurePassword123!",
         actor_crn=user_crn,
     )
-

--- a/tests/unit/plugins/modules/iam_user/test_iam_user.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user.py
@@ -209,7 +209,6 @@ def test_iam_user_create(module_args, mocker):
         first_name="Test",
         last_name="User",
         saml_provider_name="mtaabich-test",
-        groups=None,
     )
 
 
@@ -250,6 +249,7 @@ def test_iam_user_create_with_groups(module_args, mocker):
         "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
         "roles": [],
         "resourceAssignments": [],
+        "groups": [],
     }
 
     client.create_user.return_value = {
@@ -260,21 +260,98 @@ def test_iam_user_create_with_groups(module_args, mocker):
         },
     }
 
+    # Mock manage_user_groups to return True (changes made)
+    client.manage_user_groups.return_value = True
+
     # Test module execution
     with pytest.raises(AnsibleExitJson) as result:
         iam_user.main()
 
     assert result.value.changed is True
 
-    # Verify CdpIamClient was called correctly
+    # Verify create_user was called without groups parameter
     client.create_user.assert_called_once_with(
         email=USER_EMAIL,
         identity_provider_user_id=IDP_USER_ID,
         first_name=None,
         last_name=None,
         saml_provider_name=None,
-        groups=["developers", "admins"],
     )
+
+    # Verify manage_user_groups was called to add user to groups
+    client.manage_user_groups.assert_called_once_with(
+        user_id=USER_ID,
+        current_groups=[],
+        desired_groups=["developers", "admins"],
+        purge=False,
+    )
+
+
+def test_iam_user_create_with_nonexistent_group(module_args, mocker):
+    """Test iam_user module fails when trying to add user to non-existent group."""
+
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDP_USER_ID,
+            "groups": ["nonexistent-group"],
+            "state": "present",
+        },
+    )
+
+    # Patch load_cdp_config to avoid reading real config files
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+
+    # Patch CdpIamClient to avoid real API calls
+    client = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.iam_user.CdpIamClient",
+        autospec=True,
+    ).return_value
+
+    # User doesn't exist initially (lookup by email)
+    client.get_user_details_by_email.return_value = None
+
+    # After creation, get_user_details returns the created user
+    client.get_user_details.return_value = {
+        "userId": USER_ID,
+        "email": USER_EMAIL,
+        "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        "roles": [],
+        "resourceAssignments": [],
+        "groups": [],
+    }
+
+    client.create_user.return_value = {
+        "user": {
+            "userId": USER_ID,
+            "email": USER_EMAIL,
+            "crn": f"crn:cdp:iam:us-west-1:altus:user:{USER_ID}",
+        },
+    }
+
+    # Mock manage_user_groups to raise CdpError for non-existent group
+    from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
+        CdpError,
+    )
+
+    client.manage_user_groups.side_effect = CdpError(
+        "Group 'nonexistent-group' does not exist. "
+        "Please create the group using the iam_group module before adding users to it.",
+        status=404,
+    )
+
+    # Test module execution - should fail
+    with pytest.raises(CdpError) as exc_info:
+        iam_user.main()
+
+    assert "nonexistent-group" in str(exc_info.value)
+    assert "does not exist" in str(exc_info.value)
 
 
 def test_iam_user_present_no_changes(module_args, mocker):

--- a/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
@@ -177,7 +177,6 @@ def test_iam_user_create(iam_module_args, iam_user_delete):
 def test_iam_user_delete(iam_module_args, iam_user_create, env_context):
     """Test deleting an IAM user with real API calls using user_id."""
 
-
     # Create the user to be deleted
     created_user = iam_user_create(
         email=USER_EMAIL,
@@ -317,13 +316,12 @@ def test_iam_user_update_workload_password(
 ):
     """Test updating workload password for an existing IAM user."""
 
-
     iam_module_args(
         {
             "email": USER_EMAIL,
             "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
             "saml_provider_name": env_context["SAML_PROVIDER_NAME"],
-            "workload_password":  TEST_WORKLOAD_PASSWORD,
+            "workload_password": TEST_WORKLOAD_PASSWORD,
             "state": "present",
         },
     )
@@ -351,4 +349,3 @@ def test_iam_user_update_workload_password(
 
     assert result.value.changed is True
     assert result.value.user["email"] == USER_EMAIL
-

--- a/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
@@ -83,7 +83,8 @@ def iam_user_delete(
 
 @pytest.fixture
 def iam_user_create(
-    iam_client, iam_user_delete
+    iam_client,
+    iam_user_delete,
 ) -> Callable[[str, str, str], dict]:
     """Fixture to create IAM users for tests."""
 
@@ -110,7 +111,6 @@ def test_iam_user(test_cdp_client, iam_client):
     assert iam_result
 
 
-
 def test_iam_user_create(module_args, iam_user_delete):
     """Test creating a new IAM user with real API calls."""
 
@@ -132,7 +132,7 @@ def test_iam_user_create(module_args, iam_user_delete):
     assert result.value.changed is True
     assert result.value.user["email"] == USER_EMAIL
     assert "crn" in result.value.user
-    
+
     # Register for cleanup after the test
     iam_user_delete(result.value.user["user_id"])
 
@@ -167,7 +167,7 @@ def test_iam_user_delete(module_args, iam_user_create, env_context):
     created_user = iam_user_create(
         email=USER_EMAIL,
         idp_user_id=IDENTITY_PROVIDER_USER_ID,
-        saml_provider_name=env_context["SAML_PROVIDER_NAME"]
+        saml_provider_name=env_context["SAML_PROVIDER_NAME"],
     )
 
     # Execute function - use userId from created user (API returns camelCase)
@@ -191,7 +191,6 @@ def test_iam_user_delete(module_args, iam_user_create, env_context):
         iam_user.main()
 
     assert result.value.changed is False
-
 
 
 def test_iam_user_roles_update(module_args, iam_user_delete, env_context):
@@ -225,14 +224,13 @@ def test_iam_user_roles_update(module_args, iam_user_delete, env_context):
     assert result.value.user["email"] == USER_EMAIL
     assert len(result.value.user["roles"]) == 2
     assert (
-        "crn:altus:iam:us-west-1:altus:role:BillingAdmin"
-        in result.value.user["roles"]
+        "crn:altus:iam:us-west-1:altus:role:BillingAdmin" in result.value.user["roles"]
     )
     assert (
         "crn:altus:iam:us-west-1:altus:role:ClassicClustersCreator"
         in result.value.user["roles"]
     )
-    
+
     # Register for cleanup after the test
     iam_user_delete(result.value.user["user_id"])
 
@@ -260,8 +258,7 @@ def test_iam_user_roles_update(module_args, iam_user_delete, env_context):
     assert len(result.value.user["roles"]) == 5
     # Verify all roles are present
     assert (
-        "crn:altus:iam:us-west-1:altus:role:BillingAdmin"
-        in result.value.user["roles"]
+        "crn:altus:iam:us-west-1:altus:role:BillingAdmin" in result.value.user["roles"]
     )
     assert (
         "crn:altus:iam:us-west-1:altus:role:ClassicClustersCreator"
@@ -286,4 +283,3 @@ def test_iam_user_roles_update(module_args, iam_user_delete, env_context):
 
     assert result.value.changed is False
     assert len(result.value.user["roles"]) == 5
-

--- a/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+__metaclass__ = type
+
+import os
+
+import uuid
+
+from typing import Callable, Generator
+
+from ansible_collections.cloudera.cloud.tests.unit import (
+    AnsibleExitJson,
+)
+
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
+    CdpError,
+)
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_iam import (
+    CdpIamClient,
+)
+from ansible_collections.cloudera.cloud.plugins.modules import iam_user
+
+
+BASE_URL = os.getenv("CDP_API_ENDPOINT", "not set")
+ACCESS_KEY = os.getenv("CDP_ACCESS_KEY_ID", "not set")
+PRIVATE_KEY = os.getenv("CDP_PRIVATE_KEY", "not set")
+
+# Generate unique user identifier for each test run to avoid conflicts
+USER_EMAIL = f"test-user-int-{uuid.uuid4().hex[:8]}@example.com"
+IDENTITY_PROVIDER_USER_ID = USER_EMAIL
+
+# Mark all tests in this module as integration tests requiring API credentials
+pytestmark = pytest.mark.integration_api
+
+
+@pytest.fixture
+def iam_client(test_cdp_client) -> CdpIamClient:
+    """Fixture to provide an IAM client for tests."""
+    return CdpIamClient(api_client=test_cdp_client)
+
+
+@pytest.fixture
+def iam_user_delete(
+    iam_client,
+) -> Generator[Callable[[str], None], None, None]:
+    """Fixture to clean up IAM users created during tests."""
+
+    user_ids = []
+
+    def _iam_user_delete(user_id: str):
+        user_ids.append(user_id)
+        return
+
+    yield _iam_user_delete
+
+    for user_id in user_ids:
+        try:
+            iam_client.delete_user(user_id=user_id)
+        except CdpError as e:
+            if e.status == 404:
+                continue
+        except Exception as e:
+            pytest.fail(f"Failed to clean up IAM user: {user_id}. {e}")
+
+
+@pytest.fixture
+def iam_user_create(
+    iam_client, iam_user_delete
+) -> Callable[[str, str, str], dict]:
+    """Fixture to create IAM users for tests."""
+
+    def _iam_user_create(email: str, idp_user_id: str, saml_provider_name: str):
+        result = iam_client.create_user(
+            email=email,
+            identity_provider_user_id=idp_user_id,
+            saml_provider_name=saml_provider_name,
+        )
+        iam_user_delete(result["user"]["userId"])
+        return result["user"]
+
+    return _iam_user_create
+
+
+@pytest.mark.skip("Utility test, not part of main suite")
+def test_iam_user(test_cdp_client, iam_client):
+    """Test that the IAM client can successfully make an API call."""
+
+    rest_result = test_cdp_client.post("/iam/getUser", data={})
+    assert "user" in rest_result
+
+    iam_result = iam_client.get_user()
+    assert iam_result
+
+
+
+def test_iam_user_create(module_args, iam_user_delete):
+    """Test creating a new IAM user with real API calls."""
+
+    # Execute function
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "state": "present",
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user["email"] == USER_EMAIL
+    assert "crn" in result.value.user
+    
+    # Register for cleanup after the test
+    iam_user_delete(result.value.user["user_id"])
+
+    # Idempotency check - update module_args with user_id from created user
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "state": "present",
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is False
+    assert result.value.user["email"] == USER_EMAIL
+    assert "crn" in result.value.user
+
+
+def test_iam_user_delete(module_args, iam_user_create, env_context):
+    """Test deleting an IAM user with real API calls using user_id."""
+
+    # Validate required environment variables
+    if not env_context.get("SAML_PROVIDER_NAME"):
+        pytest.skip("SAML_PROVIDER_NAME environment variable not set")
+
+    # Create the user to be deleted
+    created_user = iam_user_create(
+        email=USER_EMAIL,
+        idp_user_id=IDENTITY_PROVIDER_USER_ID,
+        saml_provider_name=env_context["SAML_PROVIDER_NAME"]
+    )
+
+    # Execute function - use userId from created user (API returns camelCase)
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "state": "absent",
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Idempotency check
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is False
+
+
+
+def test_iam_user_roles_update(module_args, iam_user_delete, env_context):
+    """Test updating IAM user roles with real API calls."""
+
+    # Validate required environment variables
+    if not env_context.get("SAML_PROVIDER_NAME"):
+        pytest.skip("SAML_PROVIDER_NAME environment variable not set")
+
+    # Create user with initial roles
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "saml_provider_name": env_context["SAML_PROVIDER_NAME"],
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+                "crn:altus:iam:us-west-1:altus:role:ClassicClustersCreator",
+            ],
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user["email"] == USER_EMAIL
+    assert len(result.value.user["roles"]) == 2
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:BillingAdmin"
+        in result.value.user["roles"]
+    )
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:ClassicClustersCreator"
+        in result.value.user["roles"]
+    )
+    
+    # Register for cleanup after the test
+    iam_user_delete(result.value.user["user_id"])
+
+    # Update roles - add three new roles (use user_id instead of email)
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "email": USER_EMAIL,
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:DFCatalogAdmin",
+                "crn:altus:iam:us-west-1:altus:role:DFCatalogPublisher",
+                "crn:altus:iam:us-west-1:altus:role:DFCatalogViewer",
+            ],
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user["email"] == USER_EMAIL
+    assert len(result.value.user["roles"]) == 5
+    # Verify all roles are present
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:BillingAdmin"
+        in result.value.user["roles"]
+    )
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:ClassicClustersCreator"
+        in result.value.user["roles"]
+    )
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:DFCatalogAdmin"
+        in result.value.user["roles"]
+    )
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:DFCatalogPublisher"
+        in result.value.user["roles"]
+    )
+    assert (
+        "crn:altus:iam:us-west-1:altus:role:DFCatalogViewer"
+        in result.value.user["roles"]
+    )
+
+    # Idempotency check
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is False
+    assert len(result.value.user["roles"]) == 5
+

--- a/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
@@ -16,12 +16,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 __metaclass__ = type
 
-import os
-
+import pytest
 import uuid
 
 from typing import Callable, Generator

--- a/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
+++ b/tests/unit/plugins/modules/iam_user/test_iam_user_int.py
@@ -346,3 +346,241 @@ def test_iam_user_update_workload_password(
 
     assert result.value.changed is True
     assert result.value.user["email"] == USER_EMAIL
+
+
+def test_iam_user_create_diff_mode_int(iam_module_args, iam_user_delete):
+    """Test creating a new IAM user with diff mode enabled."""
+
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "first_name": "John",
+            "last_name": "Doe",
+            "roles": ["crn:altus:iam:us-west-1:altus:role:BillingAdmin"],
+            "state": "present",
+            "_ansible_diff": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert result.value.user["email"] == USER_EMAIL
+    assert result.value.user["first_name"] == "John"
+    assert result.value.user["last_name"] == "Doe"
+
+    # Verify diff structure
+    assert hasattr(result.value, "diff")
+    assert result.value.diff["before"] == {}
+    assert "after" in result.value.diff
+
+    # Verify diff contains the expected fields
+    assert result.value.diff["after"]["email"] == USER_EMAIL
+    assert result.value.diff["after"]["first_name"] == "John"
+    assert result.value.diff["after"]["last_name"] == "Doe"
+    assert result.value.diff["after"]["roles"] == [
+        "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+    ]
+
+    # Register for cleanup after the test
+    iam_user_delete(result.value.user["user_id"])
+
+
+def test_iam_user_delete_diff_mode_int(iam_module_args, iam_user_create, env_context):
+    """Test deleting an IAM user with diff mode enabled."""
+
+    # Create the user to be deleted
+    created_user = iam_user_create(
+        email=USER_EMAIL,
+        idp_user_id=IDENTITY_PROVIDER_USER_ID,
+        saml_provider_name=env_context["SAML_PROVIDER_NAME"],
+    )
+
+    # Execute delete with diff mode
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "state": "absent",
+            "_ansible_diff": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert hasattr(result.value, "diff")
+    assert "before" in result.value.diff
+    assert result.value.diff["before"]["email"] == USER_EMAIL
+    assert result.value.diff["after"] == {}
+
+
+def test_iam_user_update_roles_diff_mode_int(
+    iam_module_args,
+    iam_user_delete,
+    env_context,
+):
+    """Test updating user roles with diff mode enabled."""
+
+    # Create user with initial roles
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "saml_provider_name": env_context["SAML_PROVIDER_NAME"],
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+            ],
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    user_id = result.value.user["user_id"]
+
+    # Register for cleanup after the test
+    iam_user_delete(user_id)
+
+    # Update roles with diff mode
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+                "crn:altus:iam:us-west-1:altus:role:DFCatalogAdmin",
+            ],
+            "_ansible_diff": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert hasattr(result.value, "diff")
+    assert "before" in result.value.diff
+    assert "after" in result.value.diff
+    assert "roles" in result.value.diff["before"]
+    assert "roles" in result.value.diff["after"]
+    assert len(result.value.diff["after"]["roles"]) == 2
+
+
+def test_iam_user_check_mode_create_int(iam_module_args, iam_client):
+    """Test creating a user in check mode - should not create actual user."""
+
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "first_name": "Check",
+            "last_name": "Mode",
+            "state": "present",
+            "_ansible_check_mode": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify user was NOT actually created
+    existing_user = iam_client.get_user_details_by_email(email=USER_EMAIL)
+    assert existing_user is None
+
+
+def test_iam_user_check_mode_delete_int(
+    iam_module_args,
+    iam_user_create,
+    iam_client,
+    env_context,
+):
+    """Test deleting a user in check mode - should not delete actual user."""
+
+    # Create the user
+    created_user = iam_user_create(
+        email=USER_EMAIL,
+        idp_user_id=IDENTITY_PROVIDER_USER_ID,
+        saml_provider_name=env_context["SAML_PROVIDER_NAME"],
+    )
+
+    # Try to delete in check mode
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "state": "absent",
+            "_ansible_check_mode": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+
+    # Verify user still exists
+    existing_user = iam_client.get_user_details_by_email(email=USER_EMAIL)
+    assert existing_user is not None
+    assert existing_user["email"] == USER_EMAIL
+
+
+def test_iam_user_check_mode_update_diff_int(
+    iam_module_args,
+    iam_user_delete,
+    env_context,
+):
+    """Test updating user in check mode with diff - should show changes without applying."""
+
+    # Create user with initial roles
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "identity_provider_user_id": IDENTITY_PROVIDER_USER_ID,
+            "saml_provider_name": env_context["SAML_PROVIDER_NAME"],
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+            ],
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    user_id = result.value.user["user_id"]
+    original_roles = result.value.user["roles"]
+
+    # Register for cleanup after the test
+    iam_user_delete(user_id)
+
+    # Update roles in check mode with diff
+    iam_module_args(
+        {
+            "email": USER_EMAIL,
+            "state": "present",
+            "roles": [
+                "crn:altus:iam:us-west-1:altus:role:BillingAdmin",
+                "crn:altus:iam:us-west-1:altus:role:DFCatalogAdmin",
+            ],
+            "_ansible_check_mode": True,
+            "_ansible_diff": True,
+        },
+    )
+
+    with pytest.raises(AnsibleExitJson) as result:
+        iam_user.main()
+
+    assert result.value.changed is True
+    assert hasattr(result.value, "diff")
+    assert "before" in result.value.diff
+    assert "after" in result.value.diff
+
+    # Verify roles were NOT actually changed
+    assert result.value.user["roles"] == original_roles


### PR DESCRIPTION
This PR Contains:
* New **_iam_user.py_** Ansible module for managing CDP IAM users, supporting create, update, delete, and assignment of roles, resource roles, and groups.
* Extended **_cdp_iam.py_** with additional user management methods to support all required IAM user operations for the module.
* Added unit and integration tests for _**iam_user.py**_ with full mocking of the API client