### PR TITLE
Add installed packages header for pytest execution and add Python 3.14 to matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import importlib.metadata
+
+
+def pytest_report_header(config):
+    """Injects the environment's package matrix into the pytest header block."""
+    try:
+        dists = importlib.metadata.distributions()
+        pkgs = sorted([f"  - {d.name}=={d.version}" for d in dists])
+        return ["Matrix Environment Packages:"] + pkgs
+    except Exception as e:
+        return [f"Matrix Environment Packages: Error loading dependencies ({e})"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,23 +53,23 @@ extra-dependencies = [
 
 [tool.hatch.envs.hatch-test.scripts]
 run = [
-    "pip list --verbose",
+    # "pip list --verbose",
     "pytest{env:HATCH_TEST_ARGS:} {args}"
 ]
 
 # Ansible 2.18 - Python >= 3.11
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13", "3.12", "3.11"]
+python = ["3.14", "3.13", "3.12", "3.11"]
 ansible = ["2.18"]
 
 # Ansible 2.17 - Python >= 3.10
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 ansible = ["2.17"]
 
 # Ansible 2.16 - Python >= 3.10
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 ansible = ["2.16"]
 
 # Ansible 2.15 - Python <= 3.12, >=3.10


### PR DESCRIPTION
Useful for debugging `hatch test` runs