### PR TITLE
Add compute_default module for AWS/Azure default compute cluster

### DIFF
--- a/plugins/module_utils/cdp_env.py
+++ b/plugins/module_utils/cdp_env.py
@@ -397,3 +397,90 @@ class CdpEnvClient:
                     filtered_ids.append(subnet_id)
 
         return filtered_ids
+
+    # ========================================================================
+    # Default Compute Cluster Initialization Methods
+    # ========================================================================
+
+    def initialize_aws_compute_cluster(
+        self,
+        environment_name: str,
+        private_cluster: Optional[bool] = None,
+        kube_api_authorized_ip_ranges: Optional[List[str]] = None,
+        worker_node_subnets: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Initialize the default compute cluster for an AWS environment.
+
+        Args:
+            environment_name: Name of the CDP environment (name, not CRN)
+            private_cluster: If True, creates a private cluster. Mutually exclusive
+                with kube_api_authorized_ip_ranges.
+            kube_api_authorized_ip_ranges: Kubernetes API authorized IP ranges in
+                CIDR notation. Mutually exclusive with private_cluster.
+            worker_node_subnets: Subnet IDs for Kubernetes worker nodes.
+
+        Returns:
+            Dictionary containing:
+                - operationId: ID of the triggered operation
+        """
+        config: Dict[str, Any] = {}
+        if private_cluster is not None:
+            config["privateCluster"] = private_cluster
+        if kube_api_authorized_ip_ranges is not None:
+            config["kubeApiAuthorizedIpRanges"] = kube_api_authorized_ip_ranges
+        if worker_node_subnets is not None:
+            config["workerNodeSubnets"] = worker_node_subnets
+
+        data: Dict[str, Any] = {"environmentName": environment_name}
+        if config:
+            data["computeClusterConfiguration"] = config
+
+        return self.api_client.post(
+            "/api/v1/environments2/initializeAWSComputeCluster",
+            data=data,
+        )
+
+    def initialize_azure_compute_cluster(
+        self,
+        environment_name: str,
+        private_cluster: Optional[bool] = None,
+        kube_api_authorized_ip_ranges: Optional[List[str]] = None,
+        worker_node_subnets: Optional[List[str]] = None,
+        outbound_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Initialize the default compute cluster for an Azure environment.
+
+        Args:
+            environment_name: Name of the CDP environment (name, not CRN)
+            private_cluster: If True, creates a private cluster. Mutually exclusive
+                with kube_api_authorized_ip_ranges.
+            kube_api_authorized_ip_ranges: Kubernetes API authorized IP ranges in
+                CIDR notation. Mutually exclusive with private_cluster.
+            worker_node_subnets: Subnet IDs for Kubernetes worker nodes.
+            outbound_type: Customize cluster egress with defined outbound type in
+                Azure Kubernetes Service. Valid values: "udr".
+
+        Returns:
+            Dictionary containing:
+                - operationId: ID of the triggered operation
+        """
+        config: Dict[str, Any] = {}
+        if private_cluster is not None:
+            config["privateCluster"] = private_cluster
+        if kube_api_authorized_ip_ranges is not None:
+            config["kubeApiAuthorizedIpRanges"] = kube_api_authorized_ip_ranges
+        if worker_node_subnets is not None:
+            config["workerNodeSubnets"] = worker_node_subnets
+        if outbound_type is not None:
+            config["outboundType"] = outbound_type
+
+        data: Dict[str, Any] = {"environmentName": environment_name}
+        if config:
+            data["computeClusterConfiguration"] = config
+
+        return self.api_client.post(
+            "/api/v1/environments2/initializeAzureComputeCluster",
+            data=data,
+        )

--- a/plugins/modules/compute_default.py
+++ b/plugins/modules/compute_default.py
@@ -1,0 +1,419 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION = r"""
+module: compute_default
+short_description: Initialize the default compute cluster for a CDP Environment
+description:
+  - Initializes the default (embedded, environment-scoped) compute cluster for
+    a CDP Environment on AWS or Azure.
+  - The cloud provider is detected automatically from the environment's
+    C(cloudPlatform) field.
+  - The module is idempotent. If a default compute cluster already exists for
+    the environment it returns the existing cluster details without making any
+    API calls.
+  - Deletion of default compute clusters is not supported by the CDP API.
+    This module only supports O(state=present).
+  - The module supports check_mode.
+author:
+    - "Jim Enright (@jimright)"
+version_added: "3.6.0"
+options:
+  environment:
+    description:
+      - The name of the CDP environment.
+      - The environment name (not CRN) is required; the CDP environments API
+        accepts only an environment name for this operation.
+    type: str
+    required: true
+    aliases:
+      - env
+  private_cluster:
+    description:
+      - If C(true), the compute cluster will be created as a private cluster.
+      - Mutually exclusive with O(kube_api_authorized_ip_ranges).
+    type: bool
+    required: false
+  kube_api_authorized_ip_ranges:
+    description:
+      - List of CIDR blocks authorized to access the Kubernetes API server.
+      - Mutually exclusive with O(private_cluster).
+    type: list
+    elements: str
+    required: false
+  worker_node_subnets:
+    description:
+      - List of subnet IDs to use for Kubernetes worker nodes.
+    type: list
+    elements: str
+    required: false
+  outbound_type:
+    description:
+      - Customize the cluster egress with a defined outbound type in Azure
+        Kubernetes Service.
+      - Valid values are C(udr) (User-Defined Routing).
+      - This parameter applies to Azure environments only and is ignored
+        for AWS environments.
+    type: str
+    required: false
+    choices:
+      - udr
+  wait:
+    description:
+      - If C(true), wait for the default cluster to reach a running state
+        before returning.
+      - If C(false), return immediately after issuing the initialization
+        request with the operation ID.
+    type: bool
+    required: false
+    default: true
+  delay:
+    description:
+      - The polling interval in seconds while waiting for the cluster to
+        reach a running state.
+    type: int
+    required: false
+    default: 15
+    aliases:
+      - polling_delay
+  timeout:
+    description:
+      - The maximum time in seconds to wait for the cluster to reach a
+        running state.
+    type: int
+    required: false
+    default: 3600
+    aliases:
+      - polling_timeout
+  state:
+    description:
+      - Desired state of the default compute cluster.
+      - Only C(present) is supported. The CDP API does not provide a delete
+        operation for default compute clusters.
+    type: str
+    required: false
+    choices:
+      - present
+    default: present
+extends_documentation_fragment:
+  - ansible.builtin.action_common_attributes
+  - cloudera.cloud.cdp_client
+attributes:
+  check_mode:
+    support: full
+  platform:
+    platforms: all
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details.
+
+# Initialize the default compute cluster for an AWS environment
+# The cloud provider is detected automatically from the environment
+- cloudera.cloud.compute_default:
+    environment: my-aws-environment
+    state: present
+
+# Initialize with specific worker node subnets on AWS
+- cloudera.cloud.compute_default:
+    environment: my-aws-environment
+    worker_node_subnets:
+      - subnet-0abc123def456789a
+      - subnet-0abc123def456789b
+    state: present
+
+# Initialize as a private cluster on AWS
+- cloudera.cloud.compute_default:
+    environment: my-aws-environment
+    private_cluster: true
+    state: present
+
+# Initialize the default compute cluster for an Azure environment with UDR egress
+- cloudera.cloud.compute_default:
+    environment: my-azure-environment
+    outbound_type: udr
+    state: present
+"""
+
+RETURN = r"""
+cluster:
+  description: Details of the default compute cluster after initialization.
+  returned: when O(wait=true) and cluster is running
+  type: dict
+  contains:
+    cluster_crn:
+      description: Compute cluster CRN.
+      returned: always
+      type: str
+    cluster_id:
+      description: Compute cluster ID.
+      returned: always
+      type: str
+    cluster_name:
+      description: Compute cluster name.
+      returned: always
+      type: str
+    status:
+      description: Current cluster status.
+      returned: always
+      type: str
+    env_crn:
+      description: CRN of the CDP environment.
+      returned: when available
+      type: str
+    env_name:
+      description: Name of the CDP environment.
+      returned: when available
+      type: str
+    compute_platform:
+      description: Underlying compute platform (e.g. C(EKS), C(AKS)).
+      returned: when available
+      type: str
+    is_default:
+      description: Whether this is the default cluster for its environment.
+      returned: when available
+      type: bool
+    creation_time:
+      description: Cluster creation time in ISO format.
+      returned: when available
+      type: str
+operation_id:
+  description: The ID of the initialization operation.
+  returned: when O(wait=false) and the cluster was initialized
+  type: str
+sdk_out:
+  description: Returns the captured CDP SDK log.
+  returned: when supported
+  type: str
+sdk_out_lines:
+  description: Returns a list of each line of the captured CDP SDK log.
+  returned: when supported
+  type: list
+  elements: str
+"""
+
+import time
+from typing import Any, Dict, List, Optional
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.cloudera.cloud.plugins.module_utils.common import (
+    ServicesModule,
+)
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_env import (
+    CdpEnvClient,
+)
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_compute import (
+    CdpComputeClient,
+)
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_client import (
+    CdpError,
+)
+
+
+class ComputeDefaultCluster(ServicesModule):
+    def __init__(self):
+        super().__init__(
+            argument_spec=dict(
+                environment=dict(required=True, type="str", aliases=["env"]),
+                private_cluster=dict(required=False, type="bool"),
+                kube_api_authorized_ip_ranges=dict(
+                    required=False,
+                    type="list",
+                    elements="str",
+                ),
+                worker_node_subnets=dict(
+                    required=False,
+                    type="list",
+                    elements="str",
+                ),
+                outbound_type=dict(
+                    required=False,
+                    type="str",
+                    choices=["udr"],
+                ),
+                wait=dict(required=False, type="bool", default=True),
+                delay=dict(
+                    required=False,
+                    type="int",
+                    default=15,
+                    aliases=["polling_delay"],
+                ),
+                timeout=dict(
+                    required=False,
+                    type="int",
+                    default=3600,
+                    aliases=["polling_timeout"],
+                ),
+                state=dict(
+                    required=False,
+                    type="str",
+                    choices=["present"],
+                    default="present",
+                ),
+            ),
+            supports_check_mode=True,
+            mutually_exclusive=[["private_cluster", "kube_api_authorized_ip_ranges"]],
+        )
+
+        # Set parameters
+        self.environment = self.get_param("environment")
+        self.private_cluster = self.get_param("private_cluster")
+        self.kube_api_authorized_ip_ranges = self.get_param(
+            "kube_api_authorized_ip_ranges",
+        )
+        self.worker_node_subnets = self.get_param("worker_node_subnets")
+        self.outbound_type = self.get_param("outbound_type")
+        self.wait = self.get_param("wait")
+        self.delay = self.get_param("delay")
+        self.timeout = self.get_param("timeout")
+
+        # Initialize return values
+        self.cluster: Dict[str, Any] = {}
+        self.operation_id: Optional[str] = None
+        self.changed = False
+
+    def process(self):
+        compute_client = CdpComputeClient(self.api_client)
+        env_client = CdpEnvClient(self.api_client)
+
+        # Resolve the environment to detect cloud platform
+        env_summary = env_client.get_environment_by_name(self.environment)
+        if env_summary is None:
+            self.module.fail_json(
+                msg=f"Environment '{self.environment}' not found.",
+            )
+
+        cloud_platform = env_summary.get("cloudPlatform", "").upper()
+        if cloud_platform not in ("AWS", "AZURE"):
+            self.module.fail_json(
+                msg=(
+                    f"Unsupported cloud platform '{cloud_platform}' for environment "
+                    f"'{self.environment}'. Only AWS and AZURE are supported."
+                ),
+            )
+
+        # Check for an existing default cluster in this environment
+        existing_clusters = compute_client.get_clusters_by_env(
+            self.environment,
+            default=True,
+        )
+        active_existing = [
+            c
+            for c in existing_clusters
+            if c.get("status") in CdpComputeClient.ACTIVE_STATES
+        ]
+
+        if active_existing:
+            # Default cluster already exists — idempotent
+            self.cluster = camel_dict_to_snake_dict(active_existing[0])
+            return
+
+        # No active default cluster — initialize one
+        self.changed = True
+
+        if not self.module.check_mode:
+            if cloud_platform == "AWS":
+                response = env_client.initialize_aws_compute_cluster(
+                    environment_name=self.environment,
+                    private_cluster=self.private_cluster,
+                    kube_api_authorized_ip_ranges=self.kube_api_authorized_ip_ranges,
+                    worker_node_subnets=self.worker_node_subnets,
+                )
+            else:
+                # AZURE — outbound_type only applies to Azure; not passed for AWS
+                response = env_client.initialize_azure_compute_cluster(
+                    environment_name=self.environment,
+                    private_cluster=self.private_cluster,
+                    kube_api_authorized_ip_ranges=self.kube_api_authorized_ip_ranges,
+                    worker_node_subnets=self.worker_node_subnets,
+                    outbound_type=self.outbound_type,
+                )
+
+            self.operation_id = response.get("operationId")
+
+            if self.wait:
+                self.cluster = self._wait_for_default_cluster(compute_client)
+            # wait=False: cluster and operation_id both returned via main()
+
+    def _wait_for_default_cluster(
+        self,
+        compute_client: CdpComputeClient,
+    ) -> Dict[str, Any]:
+        """
+        Poll list_clusters(default=True) until a cluster in ACTIVE_STATES appears.
+
+        No CRN is returned by the initialize API so we cannot use
+        wait_for_cluster_state directly. Instead we poll the list endpoint.
+        """
+        start_time = time.time()
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > self.timeout:
+                raise CdpError(
+                    f"Timeout waiting for default compute cluster in environment "
+                    f"'{self.environment}' to reach a running state after "
+                    f"{self.timeout} seconds",
+                )
+
+            clusters = compute_client.get_clusters_by_env(
+                self.environment,
+                default=True,
+            )
+
+            for cluster in clusters:
+                current_state = cluster.get("status")
+
+                if current_state in CdpComputeClient.ACTIVE_STATES:
+                    return camel_dict_to_snake_dict(cluster)
+
+                if current_state in CdpComputeClient.FAILED_STATES:
+                    msg = cluster.get("statusMessage", "Unknown error")
+                    raise CdpError(
+                        f"Default compute cluster entered failed state "
+                        f"'{current_state}': {msg}",
+                    )
+
+            time.sleep(self.delay)
+
+
+def main():
+    result = ComputeDefaultCluster()
+
+    output: Dict[str, Any] = dict(
+        changed=result.changed,
+        cluster=result.cluster,
+    )
+
+    # operation_id is only surfaced when wait=False (per RETURN docs).
+    # When wait=True the caller already has the cluster details; the transient
+    # operation ID is not useful and is intentionally omitted.
+    if not result.wait and result.operation_id is not None:
+        output["operation_id"] = result.operation_id
+
+    if result.debug_log:
+        output.update(
+            sdk_out=result.log_out,
+            sdk_out_lines=result.log_lines,
+        )
+
+    result.module.exit_json(**output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/compute_default.py
+++ b/plugins/modules/compute_default.py
@@ -115,6 +115,8 @@ extends_documentation_fragment:
 attributes:
   check_mode:
     support: full
+  diff_mode:
+    support: none
   platform:
     platforms: all
 """

--- a/tests/unit/plugins/module_utils/cdp_env/test_cdp_env.py
+++ b/tests/unit/plugins/module_utils/cdp_env/test_cdp_env.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from unittest.mock import MagicMock
+
+from ansible_collections.cloudera.cloud.plugins.module_utils.cdp_env import (
+    CdpEnvClient,
+)
+
+
+ENV_NAME = "test-environment"
+OPERATION_ID = "op-uuid-1234"
+
+
+def make_client():
+    """Create a CdpEnvClient with a mocked api_client."""
+    api_client = MagicMock()
+    return CdpEnvClient(api_client), api_client
+
+
+# ============================================================================
+# initialize_aws_compute_cluster tests
+# ============================================================================
+
+
+def test_initialize_aws_compute_cluster_minimal(mocker):
+    """initialize_aws_compute_cluster with only environment_name sends minimal body."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    result = client.initialize_aws_compute_cluster(ENV_NAME)
+
+    api_client.post.assert_called_once_with(
+        "/api/v1/environments2/initializeAWSComputeCluster",
+        data={"environmentName": ENV_NAME},
+    )
+    assert result == {"operationId": OPERATION_ID}
+
+
+def test_initialize_aws_compute_cluster_with_all_options(mocker):
+    """initialize_aws_compute_cluster includes computeClusterConfiguration when options are set."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_aws_compute_cluster(
+        environment_name=ENV_NAME,
+        worker_node_subnets=["subnet-abc", "subnet-def"],
+        kube_api_authorized_ip_ranges=["10.0.0.0/8", "192.168.0.0/16"],
+    )
+
+    call_data = api_client.post.call_args[1]["data"]
+    assert call_data["environmentName"] == ENV_NAME
+    assert call_data["computeClusterConfiguration"]["workerNodeSubnets"] == [
+        "subnet-abc",
+        "subnet-def",
+    ]
+    assert call_data["computeClusterConfiguration"]["kubeApiAuthorizedIpRanges"] == [
+        "10.0.0.0/8",
+        "192.168.0.0/16",
+    ]
+
+
+def test_initialize_aws_compute_cluster_private(mocker):
+    """initialize_aws_compute_cluster sets privateCluster when requested."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_aws_compute_cluster(
+        environment_name=ENV_NAME,
+        private_cluster=True,
+    )
+
+    call_data = api_client.post.call_args[1]["data"]
+    assert call_data["computeClusterConfiguration"]["privateCluster"] is True
+
+
+def test_initialize_aws_compute_cluster_omits_none_options(mocker):
+    """initialize_aws_compute_cluster omits computeClusterConfiguration when all options are None."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_aws_compute_cluster(ENV_NAME)
+
+    call_data = api_client.post.call_args[1]["data"]
+    assert "computeClusterConfiguration" not in call_data
+
+
+# ============================================================================
+# initialize_azure_compute_cluster tests
+# ============================================================================
+
+
+def test_initialize_azure_compute_cluster_minimal(mocker):
+    """initialize_azure_compute_cluster with only environment_name sends minimal body."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    result = client.initialize_azure_compute_cluster(ENV_NAME)
+
+    api_client.post.assert_called_once_with(
+        "/api/v1/environments2/initializeAzureComputeCluster",
+        data={"environmentName": ENV_NAME},
+    )
+    assert result == {"operationId": OPERATION_ID}
+
+
+def test_initialize_azure_compute_cluster_with_outbound_type(mocker):
+    """initialize_azure_compute_cluster includes outboundType in configuration."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_azure_compute_cluster(
+        environment_name=ENV_NAME,
+        outbound_type="udr",
+    )
+
+    call_data = api_client.post.call_args[1]["data"]
+    assert call_data["computeClusterConfiguration"]["outboundType"] == "udr"
+
+
+def test_initialize_azure_compute_cluster_with_all_options(mocker):
+    """initialize_azure_compute_cluster includes all configuration fields when set."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_azure_compute_cluster(
+        environment_name=ENV_NAME,
+        private_cluster=True,
+        worker_node_subnets=["subnet-abc"],
+        outbound_type="udr",
+    )
+
+    call_data = api_client.post.call_args[1]["data"]
+    config = call_data["computeClusterConfiguration"]
+    assert config["privateCluster"] is True
+    assert config["workerNodeSubnets"] == ["subnet-abc"]
+    assert config["outboundType"] == "udr"
+
+
+def test_initialize_azure_compute_cluster_omits_none_options(mocker):
+    """initialize_azure_compute_cluster omits computeClusterConfiguration when all options are None."""
+    client, api_client = make_client()
+
+    api_client.post.return_value = {"operationId": OPERATION_ID}
+
+    client.initialize_azure_compute_cluster(ENV_NAME)
+
+    call_data = api_client.post.call_args[1]["data"]
+    assert "computeClusterConfiguration" not in call_data

--- a/tests/unit/plugins/modules/compute/test_compute_default.py
+++ b/tests/unit/plugins/modules/compute/test_compute_default.py
@@ -1,0 +1,584 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.cloudera.cloud.tests.unit import (
+    AnsibleFailJson,
+    AnsibleExitJson,
+)
+
+from ansible_collections.cloudera.cloud.plugins.modules import compute_default
+
+# ============================================================================
+# Test constants
+# ============================================================================
+
+BASE_URL = "https://cloudera.internal/api"
+ACCESS_KEY = "test-access-key"
+PRIVATE_KEY = "test-private-key"
+FILE_ACCESS_KEY = "file-access-key"
+FILE_PRIVATE_KEY = "file-private-key"
+FILE_REGION = "default"
+
+ENV_NAME = "test-environment"
+CLUSTER_CRN = "crn:cdp:compute:us-west-1:tenant-uuid:cluster:cluster-uuid"
+OPERATION_ID = "op-uuid-1234"
+
+# Sample environment summaries returned by get_environment_by_name
+SAMPLE_ENV_AWS = {
+    "environmentName": ENV_NAME,
+    "crn": "crn:cdp:environments:us-west-1:tenant-uuid:environment:env-uuid",
+    "cloudPlatform": "AWS",
+    "status": "AVAILABLE",
+    "region": "us-west-1",
+    "credentialName": "my-credential",
+}
+
+SAMPLE_ENV_AZURE = {
+    "environmentName": ENV_NAME,
+    "crn": "crn:cdp:environments:us-west-1:tenant-uuid:environment:env-uuid",
+    "cloudPlatform": "AZURE",
+    "status": "AVAILABLE",
+    "region": "westeurope",
+    "credentialName": "my-credential",
+}
+
+# Sample cluster returned by get_clusters_by_env when a default cluster exists
+SAMPLE_DEFAULT_CLUSTER_RUNNING = {
+    "clusterCrn": CLUSTER_CRN,
+    "clusterId": "cluster-uuid",
+    "clusterName": "default-cluster",
+    "status": "Running",
+    "envName": ENV_NAME,
+    "isDefault": True,
+    "computePlatform": "EKS",
+}
+
+# ============================================================================
+# Patch helpers
+# ============================================================================
+
+
+def _patch_config(mocker):
+    """Patch load_cdp_config to prevent reading real credential files."""
+    config = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.module_utils.common.load_cdp_config",
+    )
+    config.return_value = (FILE_ACCESS_KEY, FILE_PRIVATE_KEY, FILE_REGION)
+    return config
+
+
+def _patch_compute_client(mocker):
+    """Patch CdpComputeClient in the compute_default module namespace.
+
+    Class-level state constants (ACTIVE_STATES, FAILED_STATES) are restored
+    to their real values so that containment checks inside process() and
+    _wait_for_default_cluster() behave correctly rather than testing against
+    a MagicMock object.
+    """
+    mock_class = mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.compute_default.CdpComputeClient",
+        autospec=True,
+    )
+    mock_class.ACTIVE_STATES = ["Running"]
+    mock_class.FAILED_STATES = ["Failed", "CreateFailed", "DeleteFailed"]
+    return mock_class.return_value
+
+
+def _patch_env_client(mocker):
+    """Patch CdpEnvClient in the compute_default module namespace."""
+    return mocker.patch(
+        "ansible_collections.cloudera.cloud.plugins.modules.compute_default.CdpEnvClient",
+        autospec=True,
+    ).return_value
+
+
+# ============================================================================
+# AWS — initialize
+# ============================================================================
+
+
+def test_compute_default_aws_initialize(module_args, mocker):
+    """AWS environment with no existing default cluster initializes one."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    env_client.initialize_aws_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    # First call: existence check → no cluster; second call: wait poll → running
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+    assert result.value.cluster["cluster_crn"] == CLUSTER_CRN
+    assert result.value.cluster["status"] == "Running"
+    assert result.value.operation_id is None  # not exposed when wait=True
+
+    env_client.initialize_aws_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=None,
+        kube_api_authorized_ip_ranges=None,
+        worker_node_subnets=None,
+    )
+    env_client.initialize_azure_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# AWS — idempotent
+# ============================================================================
+
+
+def test_compute_default_aws_idempotent(module_args, mocker):
+    """AWS environment when default cluster already exists is idempotent."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    compute_client.get_clusters_by_env.return_value = [SAMPLE_DEFAULT_CLUSTER_RUNNING]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is False
+    assert result.value.cluster["cluster_crn"] == CLUSTER_CRN
+    assert result.value.cluster["status"] == "Running"
+
+    env_client.initialize_aws_compute_cluster.assert_not_called()
+    env_client.initialize_azure_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# AWS — with optional parameters
+# ============================================================================
+
+
+def test_compute_default_aws_with_options(module_args, mocker):
+    """AWS environment passes worker_node_subnets and kube_api_authorized_ip_ranges."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "worker_node_subnets": ["subnet-abc", "subnet-def"],
+            "kube_api_authorized_ip_ranges": ["10.0.0.0/8"],
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    env_client.initialize_aws_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+
+    env_client.initialize_aws_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=None,
+        kube_api_authorized_ip_ranges=["10.0.0.0/8"],
+        worker_node_subnets=["subnet-abc", "subnet-def"],
+    )
+
+
+def test_compute_default_aws_private_cluster(module_args, mocker):
+    """AWS environment passes private_cluster=True to the init API."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "private_cluster": True,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    env_client.initialize_aws_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+
+    env_client.initialize_aws_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=True,
+        kube_api_authorized_ip_ranges=None,
+        worker_node_subnets=None,
+    )
+
+
+# ============================================================================
+# Azure — initialize
+# ============================================================================
+
+
+def test_compute_default_azure_initialize(module_args, mocker):
+    """Azure environment with no existing default cluster initializes one."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AZURE
+    env_client.initialize_azure_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+    assert result.value.cluster["cluster_crn"] == CLUSTER_CRN
+    assert result.value.cluster["status"] == "Running"
+
+    env_client.initialize_azure_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=None,
+        kube_api_authorized_ip_ranges=None,
+        worker_node_subnets=None,
+        outbound_type=None,
+    )
+    env_client.initialize_aws_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# Azure — idempotent
+# ============================================================================
+
+
+def test_compute_default_azure_idempotent(module_args, mocker):
+    """Azure environment when default cluster already exists is idempotent."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AZURE
+    compute_client.get_clusters_by_env.return_value = [SAMPLE_DEFAULT_CLUSTER_RUNNING]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is False
+    assert result.value.cluster["cluster_crn"] == CLUSTER_CRN
+
+    env_client.initialize_azure_compute_cluster.assert_not_called()
+    env_client.initialize_aws_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# Azure — with outbound_type
+# ============================================================================
+
+
+def test_compute_default_azure_with_outbound_type(module_args, mocker):
+    """Azure environment passes outbound_type to the Azure initialize method."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "outbound_type": "udr",
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AZURE
+    env_client.initialize_azure_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+
+    env_client.initialize_azure_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=None,
+        kube_api_authorized_ip_ranges=None,
+        worker_node_subnets=None,
+        outbound_type="udr",
+    )
+
+
+# ============================================================================
+# outbound_type silently ignored for AWS
+# ============================================================================
+
+
+def test_compute_default_outbound_type_ignored_for_aws(module_args, mocker):
+    """outbound_type set for an AWS environment is silently ignored; AWS init called without it."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "outbound_type": "udr",  # Azure-only — silently ignored for AWS
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    env_client.initialize_aws_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+    compute_client.get_clusters_by_env.side_effect = [
+        [],
+        [SAMPLE_DEFAULT_CLUSTER_RUNNING],
+    ]
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+
+    # AWS init was called — without outbound_type (it is not a parameter of that method)
+    env_client.initialize_aws_compute_cluster.assert_called_once_with(
+        environment_name=ENV_NAME,
+        private_cluster=None,
+        kube_api_authorized_ip_ranges=None,
+        worker_node_subnets=None,
+    )
+    # Azure init was NOT called
+    env_client.initialize_azure_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# check_mode
+# ============================================================================
+
+
+def test_compute_default_check_mode(module_args, mocker):
+    """check_mode does not call any initialize methods but still reports changed=True."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "_ansible_check_mode": True,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    compute_client.get_clusters_by_env.return_value = []
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+    assert result.value.cluster == {}
+
+    env_client.initialize_aws_compute_cluster.assert_not_called()
+    env_client.initialize_azure_compute_cluster.assert_not_called()
+
+
+# ============================================================================
+# wait=False
+# ============================================================================
+
+
+def test_compute_default_no_wait(module_args, mocker):
+    """wait=False returns operation_id immediately without polling."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "wait": False,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    compute_client = _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = SAMPLE_ENV_AWS
+    compute_client.get_clusters_by_env.return_value = []
+    env_client.initialize_aws_compute_cluster.return_value = {
+        "operationId": OPERATION_ID,
+    }
+
+    with pytest.raises(AnsibleExitJson) as result:
+        compute_default.main()
+
+    assert result.value.changed is True
+    assert result.value.operation_id == OPERATION_ID
+    assert result.value.cluster == {}
+    # Only the initial existence check — no wait-poll call
+    compute_client.get_clusters_by_env.assert_called_once()
+
+
+# ============================================================================
+# Error handling — environment not found / unsupported platform
+# ============================================================================
+
+
+def test_compute_default_environment_not_found(module_args, mocker):
+    """Module fails with a clear message when the environment does not exist."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": "nonexistent-env",
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = None
+
+    with pytest.raises(AnsibleFailJson) as result:
+        compute_default.main()
+
+    assert "nonexistent-env" in str(result.value)
+
+
+def test_compute_default_unsupported_platform(module_args, mocker):
+    """Module fails with a clear message for unsupported cloud platforms (e.g. GCP)."""
+    module_args(
+        {
+            "endpoint": BASE_URL,
+            "access_key": ACCESS_KEY,
+            "private_key": PRIVATE_KEY,
+            "environment": ENV_NAME,
+            "state": "present",
+        },
+    )
+
+    _patch_config(mocker)
+    _patch_compute_client(mocker)
+    env_client = _patch_env_client(mocker)
+
+    env_client.get_environment_by_name.return_value = {
+        "environmentName": ENV_NAME,
+        "crn": "crn:cdp:environments:us-west-1:tenant-uuid:environment:env-uuid",
+        "cloudPlatform": "GCP",
+        "status": "AVAILABLE",
+        "region": "us-central1",
+        "credentialName": "my-credential",
+    }
+
+    with pytest.raises(AnsibleFailJson) as result:
+        compute_default.main()
+
+    assert "GCP" in str(result.value)


### PR DESCRIPTION
Requires methods #294. Addresses #257.  